### PR TITLE
HOTFIX - Reporter.sendMetric is sending the keys name as the value

### DIFF
--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -299,7 +299,7 @@ Napi::Value sendMetric (const Napi::CallbackInfo& info) {
       Napi::Value value = tagsObj.Get(keys[i]);
       holdValues[i] = value.ToString();
 
-      otags[i].key = (char*) holdValues[i].c_str();
+      otags[i].key = (char*) holdKeys[i].c_str();
       otags[i].value = (char*) holdValues[i].c_str();
     }
   }


### PR DESCRIPTION
closes #10 

# Problem
I'm using appoptics-apm-node to send my metrics, but when I used the TAGs I realized that the values ​​of the keys are coming with the value of the TAGs.

To reproduce the problem, I created a simple application and attached below, you need to run specifying your appoptics service key

[appoptics-bindings-node-tags-bug.zip](https://github.com/appoptics/appoptics-bindings-node/files/3169370/appoptics-bindings-node-tags-bug.zip)

```shell
npm install
APPOPTICS_SERVICE_KEY={YOUR-SERVICE-KEY} npm start
```
![image](https://user-images.githubusercontent.com/17066637/57573796-3f2b3c00-7404-11e9-9167-d63f612bdc50.png)

# Solution
Looking for at the code I realized that in the assignment of the TAGs the same object, the values ​​of the TAGs, was being passed to key and value, probably error by CTRL+C and CTRL+V

The hotfix is here, but I could not run the tests :disappointed: 