### PR TITLE
vNext

### DIFF
--- a/6.0.0-notes.md
+++ b/6.0.0-notes.md
@@ -29,6 +29,4 @@ build system dependency notes
 -> production build process should build in a debian container.
 
 pending
-- remove sampleTrace once the N-API/oboe 3.4.0+ version is released.
-- combine context and metadata completely
 - consider holding context buffer in cls?

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,7 @@
         'VCCLCompilerTool': { 'ExceptionHandling': 1 },
       },
     'include_dirs': [
-      '<!@(node -p "require(\'node-addon-api\').include")',
+      '<!@(node --no-warnings -p "require(\'node-addon-api\').include")',
     ],
     # preprocessor only (in bindings.o for some reason)
     #'cflags': ['-E'],
@@ -25,7 +25,7 @@
         ['OS in "linux"', {
         # includes reference oboe/oboe.h, so
         'include_dirs': [
-          '<!@(node -p "require(\'node-addon-api\').include")',
+          '<!@(node --no-warnings -p "require(\'node-addon-api\').include")',
             '<(module_root_dir)/'
         ],
         'libraries': [

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
+'use strict';
+
 if (process.env.NODE_ENV !== 'production') {
   try {
-    segvHandler = require('segfault-handler');
-    segvHandler.registerHandler('segv.log');
+    const segvHandler = require('segfault-handler');
+    segvHandler.registerHandler('ao-segv.log');
   } catch (e) {};
 }
 module.exports = require('bindings')('appoptics-bindings.node')
 module.exports.version = require('./package.json').version
+module.exports.init = function (sk) {
+  return module.exports.oboeInit({serviceKey: sk || process.env.APPOPTICS_SERVICE_KEY});
+}

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "scripts": {
     "test": "mocha test/*.test.js",
-    "install": "node setup-liboboe && node-gyp rebuild",
-    "rebuild": "node setup-liboboe && node-gyp rebuild"
+    "install": "node setup-liboboe.js && node-gyp rebuild",
+    "rebuild": "node setup-liboboe.js && node-gyp rebuild"
   },
   "dependencies": {
     "bindings": "~1.2.1",


### PR DESCRIPTION
- add --no-warnings to node invocations in binding.gyp. (gyp treats warnings as errors.) [AO-14656]
- specify file extension for install & rebuild npm scripts
- constrain segvHandler declaration to scope.

[AO-14656]: https://swicloud.atlassian.net/browse/AO-14656