### PR TITLE
Metrics array

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,4 @@ env.sh
 *.tmp
 *-notes.md
 working/
+bench/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,3 +136,7 @@ Find the versions of GLIBCXX required by a file
 
 `readelf -sV build/Release/appoptics-bindings.node | sed -n 's/^.*\(@GLIBCXX_[^ ]*\).*$/\1/p' | sort -u -V`
 `objdump -T /lib/x86_64-linux-gnu/libc.so.6 | sed -n 's/^.*\(GLIBCXX_[^ ]*\).*$/\1/p' | sort -u -V`
+
+Dump a `.node` file as asm (build debug for better symbols):
+
+`objdump -CRrS build/Release/ao-metrics.node  > ao-metrics.s`

--- a/bench/metadata.bench.js
+++ b/bench/metadata.bench.js
@@ -1,0 +1,46 @@
+'use strict';
+/* eslint-disable no-console */
+
+const aob = require('..');
+const Benchmark = require('benchmark');
+const crypto = require('crypto');
+
+const serviceKey = `${process.env.AO_TOKEN_PROD}:node-bench-metadata`;
+
+const status = aob.oboeInit({serviceKey});
+if (status > 0) {
+  throw new Error('failed to initialize oboe');
+}
+
+// wait 2 seconds to make sure it's ready.
+aob.Reporter.isReadyToSample(2000);
+
+const suite = new Benchmark.Suite({name: 'crypto'});
+let md1, md2, md3;
+
+suite
+  .add('oboe metadata', function () {
+    md1 = aob.Metadata.makeRandom();
+  })
+  .add('oboe metadata', function () {
+    md2 = aob.Metadata.makeRandom(1);
+  })
+  .add('crypto metadata', function () {
+    md3 = Buffer.allocUnsafe(30);
+    md3[0] = 0x2b;
+    md3[29] = 0x00;
+    crypto.randomFillSync(md3, 1, 28);
+  })
+
+  .on('complete', function () {
+    console.log(this.name);
+    for (let i = 0; i < this.length; i++) {
+      const t = this[i];
+      console.log(t.name, t.stats.mean, t.count, t.times.elapsed);
+    }
+    console.log(md1.toString(1));
+    console.log(md2.toString(1));
+    console.log(md3.toString('hex'));
+  })
+
+  .run();

--- a/binding.gyp
+++ b/binding.gyp
@@ -54,7 +54,10 @@
     # suppress warnings
     #'cflags': ['-w'],
     'sources': [
-        'src/metrics/gc.cc'
+        'src/metrics/metrics.cc',
+        'src/metrics/gc.cc',
+        'src/metrics/eventloop.cc',
+        'src/metrics/process.cc'
     ],
     'conditions': [
         ['OS in "linux"', {

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,5 @@
 {
-'targets': [
-    {
+'targets': [{
     'target_name': 'appoptics-bindings',
       'cflags!': [ '-fno-exceptions' ],
       'cflags_cc!': [ '-fno-exceptions' ],
@@ -26,7 +25,7 @@
         # includes reference oboe/oboe.h, so
         'include_dirs': [
           '<!@(node --no-warnings -p "require(\'node-addon-api\').include")',
-            '<(module_root_dir)/'
+          '<(module_root_dir)/'
         ],
         'libraries': [
             '-loboe',
@@ -36,6 +35,42 @@
         ],
         }]
     ]
-    }
-]
+  }, {
+    'target_name': 'ao-metrics',
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+      },
+      'msvs_settings': {
+        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+      },
+    'include_dirs': [
+      '<!@(node --no-warnings -p "require(\'nan\')")',
+    ],
+    # preprocessor only (in bindings.o for some reason)
+    #'cflags': ['-E'],
+    # suppress warnings
+    #'cflags': ['-w'],
+    'sources': [
+        'src/metrics/gc.cc'
+    ],
+    'conditions': [
+        ['OS in "linux"', {
+        # includes reference oboe/oboe.h, so
+        'include_dirs': [
+          '<!@(node --no-warnings -p "require(\'nan\')")',
+          '<(module_root_dir)/',
+          '<(module_root_dir)/metrics'
+        ],
+        'libraries': [
+            '-loboe',
+            '-L<(module_root_dir)/oboe/',
+            '-Wl,-rpath-link,<(module_root_dir)/oboe/',
+            '-Wl,-rpath,\$$ORIGIN/../../oboe/'
+        ],
+        }]
+    ]
+  }]
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,13 @@ module.exports.init = function (sk) {
 
 try {
   module.exports.metrics = require('bindings')('ao-metrics');
-} catch (e) {}
+} catch (e) {
+  // return an dummy metrics if this can't be loaded
+  module.exports.metrics = {
+    start () {return true},
+    stop () {return true},
+    getMetrics () {return {}}
+  }
+}
 
 

--- a/index.js
+++ b/index.js
@@ -4,10 +4,16 @@ if (process.env.NODE_ENV !== 'production') {
   try {
     const segvHandler = require('segfault-handler');
     segvHandler.registerHandler('ao-segv.log');
-  } catch (e) {};
+  } catch (e) {}
 }
 module.exports = require('bindings')('appoptics-bindings.node')
 module.exports.version = require('./package.json').version
 module.exports.init = function (sk) {
   return module.exports.oboeInit({serviceKey: sk || process.env.APPOPTICS_SERVICE_KEY});
 }
+
+try {
+  module.exports.metrics = require('bindings')('ao-metrics');
+} catch (e) {}
+
+

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
   "dependencies": {
     "bindings": "~1.2.1",
     "linux-os-info": "^2.0.0",
+    "nan": "^2.14.0",
     "node-addon-api": "^1.6.3",
     "node-gyp": "^4.0.0"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "segfault-handler": "^1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-bindings",
-  "version": "9.0.0",
+  "version": "9.0.0-alpha",
   "description": "Bindings to liboboe for the AppOptics APM agent",
   "author": "Bruce A. MacNaughton <bruce@solarwinds.cloud>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-bindings",
-  "version": "9.0.0-alpha.1",
+  "version": "9.0.0",
   "description": "Bindings to liboboe for the AppOptics APM agent",
   "author": "Bruce A. MacNaughton <bruce@solarwinds.cloud>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-bindings",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Bindings to liboboe for the AppOptics APM agent",
   "author": "Bruce A. MacNaughton <bruce@solarwinds.cloud>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appoptics-bindings",
-  "version": "9.0.0-alpha",
+  "version": "9.0.0-alpha.1",
   "description": "Bindings to liboboe for the AppOptics APM agent",
   "author": "Bruce A. MacNaughton <bruce@solarwinds.cloud>",
   "contributors": [

--- a/src/metrics/eventloop.cc
+++ b/src/metrics/eventloop.cc
@@ -4,7 +4,7 @@
 #include "hdr_histogram.h"
 #include "eventloop.h"
 
-namespace ao { namespace metrics { namespace gc {
+namespace ao { namespace metrics { namespace eventloop {
 using namespace v8;
 
 // state = 0 not initialized

--- a/src/metrics/eventloop.cc
+++ b/src/metrics/eventloop.cc
@@ -4,7 +4,7 @@
 #include "hdr_histogram.h"
 #include "eventloop.h"
 
-namespace ao::metrics::eventloop {
+namespace ao { namespace metrics { namespace gc {
 using namespace v8;
 
 // state = 0 not initialized
@@ -124,6 +124,4 @@ bool getInterval(const v8::Local<v8::Object> obj) {
   return true;
 }
 
-} // ao::metrics::eventloop
-
-
+}}} // ao::metrics::eventloop

--- a/src/metrics/eventloop.cc
+++ b/src/metrics/eventloop.cc
@@ -1,0 +1,129 @@
+#include <nan.h>
+#include <map>
+
+#include "hdr_histogram.h"
+#include "eventloop.h"
+
+namespace ao::metrics::eventloop {
+using namespace v8;
+
+// state = 0 not initialized
+// state = 1 initialized
+bool enabled = false;
+
+uv_check_t check_handle;
+uv_prepare_t prepare_handle;
+uint64_t prev_check_time;
+uint64_t prepare_time;
+uint64_t poll_timeout;
+
+struct hdr_histogram* hist;
+std::map<std::string, double> PERCENTILES = {
+  {"p50", 50.0}, {"p75", 75.0}, {"p90", 90.0}, {"p95", 95.0}, {"p99", 99.0}
+};
+
+//
+// the check callback, after i/o polling
+//
+void check_cb(uv_check_t* handle) {
+  uint64_t check_time = uv_hrtime();
+
+  // get the time i/o polling took
+  uint64_t poll_time = check_time - prepare_time;
+
+  // before-io-polling t - previous-after-polling t
+  uint64_t latency = prepare_time - prev_check_time;
+
+  // get n-sec timeout from before i/o polling
+  uint64_t timeout = poll_timeout * 1000 * 1000;
+
+  // if polling took longer than the timeout add that to latency
+  if (poll_time > timeout) {
+    latency += poll_time - timeout;
+  }
+
+  // convert latency to μ seconds and record it.
+  hdr_record_values(hist, (latency + 500) / 1000, 1);
+
+  // reset time mark
+  prev_check_time = check_time;
+}
+
+//
+// the prepare callback, before i/o polling
+//
+void prepare_cb(uv_prepare_t* handle) {
+  // mark time before i/o polling
+  prepare_time = uv_hrtime();
+
+  // get i/o polling timeout for this iteration because it's adjusted
+  // each loop, if needed, to prevent drift.
+  poll_timeout = uv_backend_timeout(uv_default_loop());
+}
+
+//
+// start, stop, getInterval
+//
+bool start() {
+  if (!enabled) {
+    uv_check_init(uv_default_loop(), &check_handle);
+    uv_prepare_init(uv_default_loop(), &prepare_handle);
+    uv_unref(reinterpret_cast<uv_handle_t*>(&check_handle));
+    uv_unref(reinterpret_cast<uv_handle_t*>(&prepare_handle));
+
+    hdr_init(1, INT64_C(3600000000), 3, &hist);
+
+    prev_check_time = uv_hrtime();
+
+    // start listening to prepare and check callbacks.
+    uv_check_start(&check_handle, &check_cb);
+    uv_prepare_start(&prepare_handle, &prepare_cb);
+    enabled = true;
+    return true;
+  }
+  return false;
+}
+
+bool stop() {
+  if (!enabled) {
+    return false;
+  }
+  uv_check_stop(&check_handle);
+  uv_prepare_stop(&prepare_handle);
+  enabled = false;
+  return true;
+}
+
+bool getInterval(const v8::Local<v8::Object> obj) {
+  if (!enabled) {
+    return false;
+  }
+  // add each configured percentile
+  std::map<std::string, double>::iterator it;
+  for (it = PERCENTILES.begin(); it != PERCENTILES.end(); it++) {
+    const int64_t p = hdr_value_at_percentile(hist, it->second);
+    Nan::Set(obj, Nan::New(it->first).ToLocalChecked(), Nan::New<Number>(p));
+  }
+  int64_t min = hdr_min(hist);
+  Nan::Set(obj, Nan::New("min").ToLocalChecked(), Nan::New<Number>(min));
+  Nan::Set(obj, Nan::New("max").ToLocalChecked(), Nan::New<Number>(hdr_max(hist)));
+
+  // use min < INT64_MAX as indication that at least one value was added
+  // to the histogram.
+  bool value_added = min < INT64_MAX;
+
+  // the next two values are NaN if no values added so default them to 0.
+  const double mean = value_added ? hdr_mean(hist) : 0;
+  Nan::Set(obj, Nan::New("mean").ToLocalChecked(), Nan::New<Number>(mean));
+  const double stddev = value_added ? hdr_stddev(hist) : 0;
+  Nan::Set(obj, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
+
+  // reset the histogram
+  hdr_reset(hist);
+
+  return true;
+}
+
+} // ao::metrics::eventloop
+
+

--- a/src/metrics/eventloop.h
+++ b/src/metrics/eventloop.h
@@ -2,7 +2,7 @@
 
 #include <nan.h>
 
-namespace ao { namespace metrics { namespace gc {
+namespace ao { namespace metrics { namespace eventloop {
   bool start();
   bool stop();
   bool getInterval(const v8::Local<v8::Object>);

--- a/src/metrics/eventloop.h
+++ b/src/metrics/eventloop.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <nan.h>
+
+namespace ao::metrics::eventloop {
+  bool start();
+  bool stop();
+  bool getInterval(const v8::Local<v8::Object>);
+}

--- a/src/metrics/eventloop.h
+++ b/src/metrics/eventloop.h
@@ -2,8 +2,8 @@
 
 #include <nan.h>
 
-namespace ao::metrics::eventloop {
+namespace ao { namespace metrics { namespace gc {
   bool start();
   bool stop();
   bool getInterval(const v8::Local<v8::Object>);
-}
+}}}

--- a/src/metrics/gc.cc
+++ b/src/metrics/gc.cc
@@ -25,7 +25,7 @@
  };
  */
 
-namespace ao::metrics::gc {
+namespace ao { namespace metrics { namespace gc {
 using namespace v8;
 
 void set_histogram_values(hdr_histogram*, Local<Object>);
@@ -198,4 +198,4 @@ void set_histogram_values(hdr_histogram* h, Local<Object> obj) {
   Nan::Set(obj, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
 }
 
-} // namespace ao::metrics::gc
+}}} // namespace ao::metrics::gc

--- a/src/metrics/gc.cc
+++ b/src/metrics/gc.cc
@@ -1,0 +1,201 @@
+#include <nan.h>
+#include <math.h>
+#include <iostream>
+#include <map>
+#include "hdr_histogram.h"
+
+using namespace v8;
+
+/* https://v8docs.nodesource.com/node-8.16/d4/da0/v8_8h_source.html#l06365
+ enum GCType {
+   kGCTypeScavenge = 1 << 0,
+   kGCTypeMarkSweepCompact = 1 << 1,
+   kGCTypeIncrementalMarking = 1 << 2,
+   kGCTypeProcessWeakCallbacks = 1 << 3,
+   kGCTypeAll = kGCTypeScavenge | kGCTypeMarkSweepCompact |
+                kGCTypeIncrementalMarking | kGCTypeProcessWeakCallbacks
+ };
+
+ enum GCCallbackFlags {
+   kNoGCCallbackFlags = 0,
+   kGCCallbackFlagConstructRetainedObjectInfos = 1 << 1,
+   kGCCallbackFlagForced = 1 << 2,
+   kGCCallbackFlagSynchronousPhantomCallbackProcessing = 1 << 3,
+   kGCCallbackFlagCollectAllAvailableGarbage = 1 << 4,
+   kGCCallbackFlagCollectAllExternalMemory = 1 << 5,
+   kGCCallbackScheduleIdleGarbageCollection = 1 << 6,
+ };
+ */
+
+const int maxTypeCount = kGCTypeAll + 1;
+typedef struct GCData {
+	uint64_t gcTime;
+    uint64_t gcCount;
+    uint64_t typeCounts[maxTypeCount];
+} GCData_t;
+
+struct hdr_histogram* histogram;
+
+GCData_t raw;
+GCData_t cumulative_base;
+GCData_t cumulative;
+
+std::map<std::string, double> PERCENTILES = {
+  {"p50", 50.0}, {"p75", 75.0}, {"p90", 90.0}, {"p95", 95.0}, {"p99", 99.0}
+};
+
+bool enabled = false;
+
+uint64_t gcStartTime;
+
+static NAN_GC_CALLBACK(recordBeforeGC) {
+	gcStartTime = uv_hrtime();
+}
+
+NAN_GC_CALLBACK(afterGC) {
+  // convert elapsed time to μ seconds
+  uint64_t et = (uv_hrtime() - gcStartTime + 500) / 1000;
+
+  // build histogram for elapsed times
+  hdr_record_values(histogram, et, 1);
+
+  // keep raw up-to-date
+  raw.gcCount += 1;
+  raw.gcTime += et;
+
+  const int index = type & kGCTypeAll;
+  raw.typeCounts[index] += 1;
+  cumulative.typeCounts[index] += 1;
+
+  // keep cumulative up-to-date
+  cumulative.gcCount += 1;
+  cumulative.gcTime += et;
+}
+
+//
+// start recording GC events
+//
+static NAN_METHOD(start) {
+  if (enabled) {
+      Nan::ThrowError("already started");
+      return;
+  }
+  enabled = true;
+
+  // cumulative base is data at last fetch of cumulative information so
+  // the first fetch is everything before.
+  memset(&cumulative_base, 0, sizeof(cumulative_base));
+  memset(&cumulative, 0, sizeof(cumulative));
+
+  hdr_init(1, INT64_C(3600000000), 3, &histogram);
+
+  Nan::AddGCPrologueCallback(recordBeforeGC);
+  Nan::AddGCEpilogueCallback(afterGC);
+
+  info.GetReturnValue().Set(Nan::New<Number>(1));
+}
+
+static NAN_METHOD(stop) {
+    int status = enabled ? 1 : 0;
+
+    if (enabled) {
+        enabled = false;
+        memset(&raw, 0, sizeof(raw));
+        memset(&cumulative_base, 0, sizeof(cumulative_base));
+        memset(&cumulative, 0, sizeof(cumulative));
+        Nan::RemoveGCPrologueCallback(recordBeforeGC);
+        Nan::RemoveGCEpilogueCallback(afterGC);
+        hdr_close(histogram);
+        histogram = nullptr;
+    }
+
+    info.GetReturnValue().Set(Nan::New<Number>(status));
+}
+
+void getCumulative(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    v8::Local<v8::Context> context = info.GetIsolate()->GetCurrentContext();
+
+    v8::Local<v8::Object> obj = Nan::New<v8::Object>();
+
+    // assign to b to avoid unused result warnings. if Set() fails there are
+    // big problems.
+    uint64_t count = raw.gcCount - cumulative_base.gcCount;
+    v8::Maybe<bool> b = obj->Set(context, Nan::New("gcCount").ToLocalChecked(),
+        Nan::New<Number>(count));
+
+    uint64_t time = raw.gcTime - cumulative_base.gcTime;
+    b = obj->Set(context, Nan::New("gcTime").ToLocalChecked(),
+        Nan::New<Number>(time));
+
+    // int64_t value = hdr_value_at_percentile(h, double percentile);
+    // percentile is 99.0, 100.0, etc.
+    // double mean = hdr_mean(h); double stddev = hdr_stddev(h);
+    // int64_t min = hdr_min(h); int64_t max = hdr_max(h);
+    std::map<std::string, double>::iterator it;
+    for (it = PERCENTILES.begin(); it != PERCENTILES.end(); it++) {
+      const int64_t p = hdr_value_at_percentile(histogram, it->second);
+      b = obj->Set(context, Nan::New(it->first).ToLocalChecked(),
+          Nan::New<Number>(p));
+    }
+    b = obj->Set(context, Nan::New("min").ToLocalChecked(),
+        Nan::New<Number>(hdr_min(histogram)));
+    b = obj->Set(context, Nan::New("max").ToLocalChecked(),
+        Nan::New<Number>(hdr_max(histogram)));
+    // the next two values are NaN if no GCs so default them to 0.
+    const double mean = count ? hdr_mean(histogram) : 0;
+    b = obj->Set(context, Nan::New("mean").ToLocalChecked(), Nan::New<Number>(mean));
+    const double stddev = count ? hdr_stddev(histogram) : 0;
+    b = obj->Set(context, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
+
+    Local<Object> counts = Nan::New<v8::Object>();
+    for (int i = 0; i < maxTypeCount; i++) {
+      uint64_t count = raw.typeCounts[i] - cumulative_base.typeCounts[i];
+      if (count != 0) {
+        Nan::Set(counts, i, Nan::New<Number>(count));
+      }
+      // reset the base
+      cumulative_base.typeCounts[i] = raw.typeCounts[i];
+    }
+    Nan::Set(obj, Nan::New("gcTypeCounts").ToLocalChecked(), counts);
+
+    // reset the cumulative base values
+    cumulative_base.gcCount = raw.gcCount;
+    cumulative_base.gcTime = raw.gcTime;
+
+    // reset the histogram
+    hdr_reset(histogram);
+
+    info.GetReturnValue().Set(obj);
+}
+
+NAN_MODULE_INIT(init) {
+	Nan::HandleScope scope;
+
+	Nan::Set(target, Nan::New("start").ToLocalChecked(),
+      Nan::GetFunction(Nan::New<FunctionTemplate>(start)).ToLocalChecked());
+	Nan::Set(target, Nan::New("stop").ToLocalChecked(),
+      Nan::GetFunction(Nan::New<FunctionTemplate>(stop)).ToLocalChecked());
+
+    Nan::Set(target, Nan::New("getCumulative").ToLocalChecked(),
+      Nan::GetFunction(Nan::New<FunctionTemplate>(getCumulative)).ToLocalChecked());
+}
+
+NODE_MODULE(metrics, init)
+
+//********************************************************************************************
+//********************************************************************************************
+// #include "hdr_histogram.h"
+//
+// struct hdr_histogram* h;
+// hdr_init(1, INT64_C(3600000000), 3, &h);
+//
+// hdr_record_values(h, value, 1);
+// hdr_record_value() just calls hdr_record_values() with a 1
+//
+// int64_t value = hdr_value_at_percentile(h, double percentile); // percentile
+// is 99.0, 100.0, etc. double mean = hdr_mean(h); double stddev =
+// hdr_stddev(h); int64_t min = hdr_min(h); int64_t max = hdr_max(h);
+//
+// hdr_reset(h); // reuse histogram.
+// hdr_close(h); // if not null.
+//

--- a/src/metrics/gc.cc
+++ b/src/metrics/gc.cc
@@ -5,24 +5,24 @@
 #include "gc.h"
 
 /* https://v8docs.nodesource.com/node-8.16/d4/da0/v8_8h_source.html#l06365
-   enum GCType {
-     kGCTypeScavenge = 1 << 0,
-     kGCTypeMarkSweepCompact = 1 << 1,
-     kGCTypeIncrementalMarking = 1 << 2,
-     kGCTypeProcessWeakCallbacks = 1 << 3,
-     kGCTypeAll = kGCTypeScavenge | kGCTypeMarkSweepCompact |
-                  kGCTypeIncrementalMarking | kGCTypeProcessWeakCallbacks
-   };
+  enum GCType {
+    kGCTypeScavenge = 1 << 0,
+    kGCTypeMarkSweepCompact = 1 << 1,
+    kGCTypeIncrementalMarking = 1 << 2,
+    kGCTypeProcessWeakCallbacks = 1 << 3,
+    kGCTypeAll = kGCTypeScavenge | kGCTypeMarkSweepCompact |
+                 kGCTypeIncrementalMarking | kGCTypeProcessWeakCallbacks
+  };
 
- enum GCCallbackFlags {
-   kNoGCCallbackFlags = 0,
-   kGCCallbackFlagConstructRetainedObjectInfos = 1 << 1,
-   kGCCallbackFlagForced = 1 << 2,
-   kGCCallbackFlagSynchronousPhantomCallbackProcessing = 1 << 3,
-   kGCCallbackFlagCollectAllAvailableGarbage = 1 << 4,
-   kGCCallbackFlagCollectAllExternalMemory = 1 << 5,
-   kGCCallbackScheduleIdleGarbageCollection = 1 << 6,
- };
+  enum GCCallbackFlags {
+    kNoGCCallbackFlags = 0,
+    kGCCallbackFlagConstructRetainedObjectInfos = 1 << 1,
+    kGCCallbackFlagForced = 1 << 2,
+    kGCCallbackFlagSynchronousPhantomCallbackProcessing = 1 << 3,
+    kGCCallbackFlagCollectAllAvailableGarbage = 1 << 4,
+    kGCCallbackFlagCollectAllExternalMemory = 1 << 5,
+    kGCCallbackScheduleIdleGarbageCollection = 1 << 6,
+  };
  */
 
 namespace ao { namespace metrics { namespace gc {
@@ -32,9 +32,9 @@ void set_histogram_values(hdr_histogram*, Local<Object>);
 
 typedef struct GCData {
 	uint64_t gcTime;
-    uint64_t gcCount;
-    uint64_t majorCount;
-    uint64_t minorCount;
+  uint64_t gcCount;
+  uint64_t majorCount;
+  uint64_t minorCount;
 } GCData_t;
 
 struct hdr_histogram* h_major;
@@ -53,7 +53,7 @@ bool enabled = false;
 uint64_t gcStartTime;
 
 static NAN_GC_CALLBACK(recordBeforeGC) {
-	gcStartTime = uv_hrtime();
+  gcStartTime = uv_hrtime();
 }
 
 NAN_GC_CALLBACK(afterGC) {
@@ -117,7 +117,7 @@ bool start() {
 }
 
 bool stop () {
-  int status = enabled ? true : false;
+  int status = enabled;
 
   if (enabled) {
     enabled = false;
@@ -132,6 +132,7 @@ bool stop () {
     h_minor = nullptr;
   }
 
+  // if it wasn't enabled return false indicating so, else true.
   return status;
 }
 

--- a/src/metrics/gc.cc
+++ b/src/metrics/gc.cc
@@ -5,14 +5,14 @@
 #include "gc.h"
 
 /* https://v8docs.nodesource.com/node-8.16/d4/da0/v8_8h_source.html#l06365
- enum GCType {
-   kGCTypeScavenge = 1 << 0,
-   kGCTypeMarkSweepCompact = 1 << 1,
-   kGCTypeIncrementalMarking = 1 << 2,
-   kGCTypeProcessWeakCallbacks = 1 << 3,
-   kGCTypeAll = kGCTypeScavenge | kGCTypeMarkSweepCompact |
-                kGCTypeIncrementalMarking | kGCTypeProcessWeakCallbacks
- };
+   enum GCType {
+     kGCTypeScavenge = 1 << 0,
+     kGCTypeMarkSweepCompact = 1 << 1,
+     kGCTypeIncrementalMarking = 1 << 2,
+     kGCTypeProcessWeakCallbacks = 1 << 3,
+     kGCTypeAll = kGCTypeScavenge | kGCTypeMarkSweepCompact |
+                  kGCTypeIncrementalMarking | kGCTypeProcessWeakCallbacks
+   };
 
  enum GCCallbackFlags {
    kNoGCCallbackFlags = 0,
@@ -28,14 +28,17 @@
 namespace ao::metrics::gc {
 using namespace v8;
 
-const int maxTypeCount = kGCTypeAll + 1;
+void set_histogram_values(hdr_histogram*, Local<Object>, uint64_t);
+
 typedef struct GCData {
 	uint64_t gcTime;
     uint64_t gcCount;
-    uint64_t typeCounts[maxTypeCount];
+    uint64_t majorCount;
+    uint64_t minorCount;
 } GCData_t;
 
-struct hdr_histogram* histogram;
+struct hdr_histogram* h_major;
+struct hdr_histogram* h_minor;
 
 GCData_t raw;
 GCData_t interval_base;
@@ -57,18 +60,30 @@ NAN_GC_CALLBACK(afterGC) {
   // convert elapsed time to μ seconds
   uint64_t et = (uv_hrtime() - gcStartTime + 500) / 1000;
 
-  // build histogram for elapsed times
-  hdr_record_values(histogram, et, 1);
+  // build histogram for elapsed times. scavenges are minor and
+  // mark/sweep/compact are major. the other two types are just
+  // phases of a major garbage collection and are typically very
+  // low values that result in a large standard deviation and lower
+  // mean if added into major garbage collections.
+  // https://stackoverflow.com/questions/60171534/what-do-v8s-incrementalmarking-and-processweakcallbacks-garbage-collections-do/60172044#60172044
+  if (type & kGCTypeMarkSweepCompact) {
+    raw.majorCount += 1;
+    interval.majorCount += 1;
+    hdr_record_values(h_major, et, 1);
+  } else if (type & kGCTypeScavenge) {
+    raw.minorCount += 1;
+    interval.minorCount += 1;
+    hdr_record_values(h_minor, et, 1);
+  } else {
+    // don't update counts or time
+    return;
+  }
 
   // keep raw up-to-date
   raw.gcCount += 1;
   raw.gcTime += et;
 
-  const int index = type & kGCTypeAll;
-  raw.typeCounts[index] += 1;
-  interval.typeCounts[index] += 1;
-
-  // keep cumulative up-to-date
+  // keep the interval data up-to-date
   interval.gcCount += 1;
   interval.gcTime += et;
 }
@@ -92,7 +107,8 @@ bool start() {
   memset(&interval_base, 0, sizeof(interval_base));
   memset(&interval, 0, sizeof(interval));
 
-  hdr_init(1, INT64_C(3600000000), 3, &histogram);
+  hdr_init(1, INT64_C(3600000000), 3, &h_major);
+  hdr_init(1, INT64_C(3600000000), 3, &h_minor);
 
   Nan::AddGCPrologueCallback(recordBeforeGC);
   Nan::AddGCEpilogueCallback(afterGC);
@@ -110,8 +126,10 @@ bool stop () {
     memset(&interval, 0, sizeof(interval));
     Nan::RemoveGCPrologueCallback(recordBeforeGC);
     Nan::RemoveGCEpilogueCallback(afterGC);
-    hdr_close(histogram);
-    histogram = nullptr;
+    hdr_close(h_major);
+    h_major = nullptr;
+    hdr_close(h_minor);
+    h_minor = nullptr;
   }
 
   return status;
@@ -129,44 +147,49 @@ bool getInterval(const v8::Local<v8::Object> obj) {
   uint64_t time = raw.gcTime - interval_base.gcTime;
   Nan::Set(obj, Nan::New("gcTime").ToLocalChecked(), Nan::New<Number>(time));
 
-  // int64_t value = hdr_value_at_percentile(h, double percentile);
-  // percentile is 99.0, 100.0, etc.
-  // double mean = hdr_mean(h); double stddev = hdr_stddev(h);
-  // int64_t min = hdr_min(h); int64_t max = hdr_max(h);
-  std::map<std::string, double>::iterator it;
-  for (it = PERCENTILES.begin(); it != PERCENTILES.end(); it++) {
-    const int64_t p = hdr_value_at_percentile(histogram, it->second);
-    Nan::Set(obj, Nan::New(it->first).ToLocalChecked(), Nan::New<Number>(p));
-  }
-  Nan::Set(obj, Nan::New("min").ToLocalChecked(), Nan::New<Number>(hdr_min(histogram)));
-  Nan::Set(obj, Nan::New("max").ToLocalChecked(), Nan::New<Number>(hdr_max(histogram)));
+  uint64_t majorCount = raw.majorCount - interval_base.majorCount;
+  uint64_t minorCount = raw.minorCount - interval_base.minorCount;
 
-  // the next two values are NaN if no GCs so default them to 0.
-  const double mean = count ? hdr_mean(histogram) : 0;
-  Nan::Set(obj, Nan::New("mean").ToLocalChecked(), Nan::New<Number>(mean));
-  const double stddev = count ? hdr_stddev(histogram) : 0;
-  Nan::Set(obj, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
+  Local<Object> major = Nan::New<Object>();
+  Local<Object> minor = Nan::New<Object>();
 
-  Local<Object> counts = Nan::New<Object>();
-  for (int i = 0; i < maxTypeCount; i++) {
-    uint64_t count = raw.typeCounts[i] - interval_base.typeCounts[i];
-    if (count != 0) {
-      Nan::Set(counts, i, Nan::New<Number>(count));
-    }
-    // reset the base
-    interval_base.typeCounts[i] = raw.typeCounts[i];
-  }
-  Nan::Set(obj, Nan::New("gcTypeCounts").ToLocalChecked(), counts);
+  set_histogram_values(h_major, major, count);
+  set_histogram_values(h_minor, minor, count);
+
+  Nan::Set(obj, Nan::New("major").ToLocalChecked(), major);
+  Nan::Set(obj, Nan::New("minor").ToLocalChecked(), minor);
+
+  Nan::Set(major, Nan::New("count").ToLocalChecked(), Nan::New<Number>(majorCount));
+  Nan::Set(minor, Nan::New("count").ToLocalChecked(), Nan::New<Number>(minorCount));
 
   // reset the interval base values
   interval_base.gcCount = raw.gcCount;
   interval_base.gcTime = raw.gcTime;
+  interval_base.majorCount = raw.majorCount;
+  interval_base.minorCount = raw.minorCount;
 
-  // reset the histogram
-  hdr_reset(histogram);
+  // reset the histograms
+  hdr_reset(h_major);
+  hdr_reset(h_minor);
 
   return true;
 }
 
+void set_histogram_values(hdr_histogram* h, Local<Object> obj, uint64_t count) {
+  std::map<std::string, double>::iterator it;
+  for (it = PERCENTILES.begin(); it != PERCENTILES.end(); it++) {
+    const int64_t p = hdr_value_at_percentile(h, it->second);
+    Nan::Set(obj, Nan::New(it->first).ToLocalChecked(), Nan::New<Number>(p));
+  }
+
+  Nan::Set(obj, Nan::New("min").ToLocalChecked(), Nan::New<Number>(hdr_min(h)));
+  Nan::Set(obj, Nan::New("max").ToLocalChecked(), Nan::New<Number>(hdr_max(h)));
+
+  // the next two values are NaN if no GCs so default them to 0.
+  const double mean = count ? hdr_mean(h) : 0;
+  Nan::Set(obj, Nan::New("mean").ToLocalChecked(), Nan::New<Number>(mean));
+  const double stddev = count ? hdr_stddev(h) : 0;
+  Nan::Set(obj, Nan::New("stddev").ToLocalChecked(), Nan::New<Number>(stddev));
+}
 
 } // namespace ao::metrics::gc

--- a/src/metrics/gc.h
+++ b/src/metrics/gc.h
@@ -2,8 +2,8 @@
 
 #include <nan.h>
 
-namespace ao::metrics::gc {
+namespace ao { namespace metrics { namespace gc {
   bool start();
   bool stop();
   bool getInterval(const v8::Local<v8::Object>);
-}
+}}}

--- a/src/metrics/gc.h
+++ b/src/metrics/gc.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <nan.h>
+
+namespace ao::metrics::gc {
+  bool start();
+  bool stop();
+  bool getInterval(const v8::Local<v8::Object>);
+}

--- a/src/metrics/hdr_histogram.h
+++ b/src/metrics/hdr_histogram.h
@@ -1,0 +1,434 @@
+/**
+ * hdr_histogram.h
+ * Written by Michael Barker and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * The source for the hdr_histogram utilises a few C99 constructs, specifically
+ * the use of stdint/stdbool and inline variable declaration.
+ */
+
+#ifndef HDR_HISTOGRAM_H
+#define HDR_HISTOGRAM_H 1
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+struct hdr_histogram
+{
+    int64_t lowest_trackable_value;
+    int64_t highest_trackable_value;
+    int32_t unit_magnitude;
+    int32_t significant_figures;
+    int32_t sub_bucket_half_count_magnitude;
+    int32_t sub_bucket_half_count;
+    int64_t sub_bucket_mask;
+    int32_t sub_bucket_count;
+    int32_t bucket_count;
+    int64_t min_value;
+    int64_t max_value;
+    int32_t normalizing_index_offset;
+    double conversion_ratio;
+    int32_t counts_len;
+    int64_t total_count;
+    int64_t* counts;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Allocate the memory and initialise the hdr_histogram.
+ *
+ * Due to the size of the histogram being the result of some reasonably
+ * involved math on the input parameters this function it is tricky to stack allocate.
+ * The histogram should be released with hdr_close
+ *
+ * @param lowest_trackable_value The smallest possible value to be put into the
+ * histogram.
+ * @param highest_trackable_value The largest possible value to be put into the
+ * histogram.
+ * @param significant_figures The level of precision for this histogram, i.e. the number
+ * of figures in a decimal number that will be maintained.  E.g. a value of 3 will mean
+ * the results from the histogram will be accurate up to the first three digits.  Must
+ * be a value between 1 and 5 (inclusive).
+ * @param result Output parameter to capture allocated histogram.
+ * @return 0 on success, EINVAL if lowest_trackable_value is < 1 or the
+ * significant_figure value is outside of the allowed range, ENOMEM if malloc
+ * failed.
+ */
+int hdr_init(
+    int64_t lowest_trackable_value,
+    int64_t highest_trackable_value,
+    int significant_figures,
+    struct hdr_histogram** result);
+
+/**
+ * Free the memory and close the hdr_histogram.
+ *
+ * @param h The histogram you want to close.
+ */
+void hdr_close(struct hdr_histogram* h);
+
+/**
+ * Allocate the memory and initialise the hdr_histogram.  This is the equivalent of calling
+ * hdr_init(1, highest_trackable_value, significant_figures, result);
+ *
+ * @deprecated use hdr_init.
+ */
+int hdr_alloc(int64_t highest_trackable_value, int significant_figures, struct hdr_histogram** result);
+
+
+/**
+ * Reset a histogram to zero - empty out a histogram and re-initialise it
+ *
+ * If you want to re-use an existing histogram, but reset everything back to zero, this
+ * is the routine to use.
+ *
+ * @param h The histogram you want to reset to empty.
+ *
+ */
+void hdr_reset(struct hdr_histogram* h);
+
+/**
+ * Get the memory size of the hdr_histogram.
+ *
+ * @param h "This" pointer
+ * @return The amount of memory used by the hdr_histogram in bytes
+ */
+size_t hdr_get_memory_size(struct hdr_histogram* h);
+
+/**
+ * Records a value in the histogram, will round this value of to a precision at or better
+ * than the significant_figure specified at construction time.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_value(struct hdr_histogram* h, int64_t value);
+
+/**
+ * Records count values in the histogram, will round this value of to a
+ * precision at or better than the significant_figure specified at construction
+ * time.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param count Number of 'value's to add to the histogram
+ * @return false if any value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_values(struct hdr_histogram* h, int64_t value, int64_t count);
+
+
+/**
+ * Record a value in the histogram and backfill based on an expected interval.
+ *
+ * Records a value in the histogram, will round this value of to a precision at or better
+ * than the significant_figure specified at contruction time.  This is specifically used
+ * for recording latency.  If the value is larger than the expected_interval then the
+ * latency recording system has experienced co-ordinated omission.  This method fills in the
+ * values that would have occured had the client providing the load not been blocked.
+
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param expected_interval The delay between recording values.
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_corrected_value(struct hdr_histogram* h, int64_t value, int64_t expexcted_interval);
+/**
+ * Record a value in the histogram 'count' times.  Applies the same correcting logic
+ * as 'hdr_record_corrected_value'.
+ *
+ * @param h "This" pointer
+ * @param value Value to add to the histogram
+ * @param count Number of 'value's to add to the histogram
+ * @param expected_interval The delay between recording values.
+ * @return false if the value is larger than the highest_trackable_value and can't be recorded,
+ * true otherwise.
+ */
+bool hdr_record_corrected_values(struct hdr_histogram* h, int64_t value, int64_t count, int64_t expected_interval);
+
+/**
+ * Adds all of the values from 'from' to 'this' histogram.  Will return the
+ * number of values that are dropped when copying.  Values will be dropped
+ * if they around outside of h.lowest_trackable_value and
+ * h.highest_trackable_value.
+ *
+ * @param h "This" pointer
+ * @param from Histogram to copy values from.
+ * @return The number of values dropped when copying.
+ */
+int64_t hdr_add(struct hdr_histogram* h, const struct hdr_histogram* from);
+
+/**
+ * Adds all of the values from 'from' to 'this' histogram.  Will return the
+ * number of values that are dropped when copying.  Values will be dropped
+ * if they around outside of h.lowest_trackable_value and
+ * h.highest_trackable_value.
+ *
+ * @param h "This" pointer
+ * @param from Histogram to copy values from.
+ * @return The number of values dropped when copying.
+ */
+int64_t hdr_add_while_correcting_for_coordinated_omission(
+    struct hdr_histogram* h, struct hdr_histogram* from, int64_t expected_interval);
+
+/**
+ * Get minimum value from the histogram.  Will return 2^63-1 if the histogram
+ * is empty.
+ *
+ * @param h "This" pointer
+ */
+int64_t hdr_min(const struct hdr_histogram* h);
+
+/**
+ * Get maximum value from the histogram.  Will return 0 if the histogram
+ * is empty.
+ *
+ * @param h "This" pointer
+ */
+int64_t hdr_max(const struct hdr_histogram* h);
+
+/**
+ * Get the value at a specific percentile.
+ *
+ * @param h "This" pointer.
+ * @param percentile The percentile to get the value for
+ */
+int64_t hdr_value_at_percentile(const struct hdr_histogram* h, double percentile);
+
+/**
+ * Gets the standard deviation for the values in the histogram.
+ *
+ * @param h "This" pointer
+ * @return The standard deviation
+ */
+double hdr_stddev(const struct hdr_histogram* h);
+
+/**
+ * Gets the mean for the values in the histogram.
+ *
+ * @param h "This" pointer
+ * @return The mean
+ */
+double hdr_mean(const struct hdr_histogram* h);
+
+/**
+ * Determine if two values are equivalent with the histogram's resolution.
+ * Where "equivalent" means that value samples recorded for any two
+ * equivalent values are counted in a common total count.
+ *
+ * @param h "This" pointer
+ * @param a first value to compare
+ * @param b second value to compare
+ * @return 'true' if values are equivalent with the histogram's resolution.
+ */
+bool hdr_values_are_equivalent(const struct hdr_histogram* h, int64_t a, int64_t b);
+
+/**
+ * Get the lowest value that is equivalent to the given value within the histogram's resolution.
+ * Where "equivalent" means that value samples recorded for any two
+ * equivalent values are counted in a common total count.
+ *
+ * @param h "This" pointer
+ * @param value The given value
+ * @return The lowest value that is equivalent to the given value within the histogram's resolution.
+ */
+int64_t hdr_lowest_equivalent_value(const struct hdr_histogram* h, int64_t value);
+
+/**
+ * Get the count of recorded values at a specific value
+ * (to within the histogram resolution at the value level).
+ *
+ * @param h "This" pointer
+ * @param value The value for which to provide the recorded count
+ * @return The total count of values recorded in the histogram within the value range that is
+ * {@literal >=} lowestEquivalentValue(<i>value</i>) and {@literal <=} highestEquivalentValue(<i>value</i>)
+ */
+int64_t hdr_count_at_value(const struct hdr_histogram* h, int64_t value);
+
+int64_t hdr_count_at_index(const struct hdr_histogram* h, int32_t index);
+
+int64_t hdr_value_at_index(const struct hdr_histogram* h, int32_t index);
+
+struct hdr_iter_percentiles
+{
+    bool seen_last_value;
+    int32_t ticks_per_half_distance;
+    double percentile_to_iterate_to;
+    double percentile;
+};
+
+struct hdr_iter_recorded
+{
+    int64_t count_added_in_this_iteration_step;
+};
+
+struct hdr_iter_linear
+{
+    int64_t value_units_per_bucket;
+    int64_t count_added_in_this_iteration_step;
+    int64_t next_value_reporting_level;
+    int64_t next_value_reporting_level_lowest_equivalent;
+};
+
+struct hdr_iter_log
+{
+    double log_base;
+    int64_t count_added_in_this_iteration_step;
+    int64_t next_value_reporting_level;
+    int64_t next_value_reporting_level_lowest_equivalent;
+};
+
+/**
+ * The basic iterator.  This is a generic structure
+ * that supports all of the types of iteration.  Use
+ * the appropriate initialiser to get the desired
+ * iteration.
+ *
+ * @
+ */
+struct hdr_iter
+{
+    const struct hdr_histogram* h;
+    /** raw index into the counts array */
+    int32_t counts_index;
+    /** snapshot of the length at the time the iterator is created */
+    int32_t total_count;
+    /** value directly from array for the current counts_index */
+    int64_t count;
+    /** sum of all of the counts up to and including the count at this index */
+    int64_t cumulative_count;
+    /** The current value based on counts_index */
+    int64_t value;
+    int64_t highest_equivalent_value;
+    int64_t lowest_equivalent_value;
+    int64_t median_equivalent_value;
+    int64_t value_iterated_from;
+    int64_t value_iterated_to;
+
+    union
+    {
+        struct hdr_iter_percentiles percentiles;
+        struct hdr_iter_recorded recorded;
+        struct hdr_iter_linear linear;
+        struct hdr_iter_log log;
+    } specifics;
+
+    bool (* _next_fp)(struct hdr_iter* iter);
+
+};
+
+/**
+ * Initalises the basic iterator.
+ *
+ * @param itr 'This' pointer
+ * @param h The histogram to iterate over
+ */
+void hdr_iter_init(struct hdr_iter* iter, const struct hdr_histogram* h);
+
+/**
+ * Initialise the iterator for use with percentiles.
+ */
+void hdr_iter_percentile_init(struct hdr_iter* iter, const struct hdr_histogram* h, int32_t ticks_per_half_distance);
+
+/**
+ * Initialise the iterator for use with recorded values.
+ */
+void hdr_iter_recorded_init(struct hdr_iter* iter, const struct hdr_histogram* h);
+
+/**
+ * Initialise the iterator for use with linear values.
+ */
+void hdr_iter_linear_init(
+    struct hdr_iter* iter,
+    const struct hdr_histogram* h,
+    int64_t value_units_per_bucket);
+
+/**
+ * Initialise the iterator for use with logarithmic values
+ */
+void hdr_iter_log_init(
+    struct hdr_iter* iter,
+    const struct hdr_histogram* h,
+    int64_t value_units_first_bucket,
+    double log_base);
+
+/**
+ * Iterate to the next value for the iterator.  If there are no more values
+ * available return faluse.
+ *
+ * @param itr 'This' pointer
+ * @return 'false' if there are no values remaining for this iterator.
+ */
+bool hdr_iter_next(struct hdr_iter* iter);
+
+typedef enum
+{
+    CLASSIC,
+    CSV
+} format_type;
+
+/**
+ * Print out a percentile based histogram to the supplied stream.  Note that
+ * this call will not flush the FILE, this is left up to the user.
+ *
+ * @param h 'This' pointer
+ * @param stream The FILE to write the output to
+ * @param ticks_per_half_distance The number of iteration steps per half-distance to 100%
+ * @param value_scale Scale the output values by this amount
+ * @param format_type Format to use, e.g. CSV.
+ * @return 0 on success, error code on failure.  EIO if an error occurs writing
+ * the output.
+ */
+int hdr_percentiles_print(
+    struct hdr_histogram* h, FILE* stream, int32_t ticks_per_half_distance,
+    double value_scale, format_type format);
+
+/**
+* Internal allocation methods, used by hdr_dbl_histogram.
+*/
+struct hdr_histogram_bucket_config
+{
+    int64_t lowest_trackable_value;
+    int64_t highest_trackable_value;
+    int64_t unit_magnitude;
+    int64_t significant_figures;
+    int32_t sub_bucket_half_count_magnitude;
+    int32_t sub_bucket_half_count;
+    int64_t sub_bucket_mask;
+    int32_t sub_bucket_count;
+    int32_t bucket_count;
+    int32_t counts_len;
+};
+
+int hdr_calculate_bucket_config(
+    int64_t lowest_trackable_value,
+    int64_t highest_trackable_value,
+    int significant_figures,
+    struct hdr_histogram_bucket_config* cfg);
+
+void hdr_init_preallocated(struct hdr_histogram* h, struct hdr_histogram_bucket_config* cfg);
+
+int64_t hdr_size_of_equivalent_value_range(const struct hdr_histogram* h, int64_t value);
+
+int64_t hdr_next_non_equivalent_value(const struct hdr_histogram* h, int64_t value);
+
+int64_t hdr_median_equivalent_value(const struct hdr_histogram* h, int64_t value);
+
+/**
+ * Used to reset counters after importing data manuallying into the histogram, used by the logging code
+ * and other custom serialisation tools.
+ */
+void hdr_reset_internal_counters(struct hdr_histogram* h);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -3,7 +3,7 @@
 #include "eventloop.h"
 #include "process.h"
 
-namespace ao::metrics {
+namespace ao { namespace metrics {
   using namespace v8;
 
   NAN_METHOD(start) {
@@ -57,4 +57,4 @@ namespace ao::metrics {
   }
 
   NODE_MODULE(metrics, init)
-}
+}} // namespace ao::metrics

--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -1,0 +1,61 @@
+#include <nan.h>
+#include "gc.h"
+#include "eventloop.h"
+#include "process.h"
+
+namespace ao::metrics {
+  using namespace v8;
+
+  NAN_METHOD(start) {
+    int status = 0;
+    if (!gc::start()) status |= 0x1;
+    if (!eventloop::start()) status |= 0x2;
+    if (!process::start()) status |= 0x4;
+
+    info.GetReturnValue().Set(status);
+  }
+
+  NAN_METHOD(stop) {
+    int status = 0;
+    if (!gc::stop()) status |= 0x1;
+    if (!eventloop::stop()) status |= 0x2;
+    if (!process::stop()) status |= 0x4;
+
+    info.GetReturnValue().Set(status);
+  }
+
+  NAN_METHOD(getMetrics) {
+    Local<Object> metrics = Nan::New<Object>();
+
+    Local<Object> obj = Nan::New<Object>();
+    if (gc::getInterval(obj)) {
+      Nan::Set(metrics, Nan::New("gc").ToLocalChecked(), obj);
+    }
+
+    obj = Nan::New<Object>();
+    if (eventloop::getInterval(obj)) {
+      Nan::Set(metrics, Nan::New("eventloop").ToLocalChecked(), obj);
+    }
+
+    obj = Nan::New<Object>();
+    if (process::getInterval(obj)) {
+      Nan::Set(metrics, Nan::New("process").ToLocalChecked(), obj);
+    }
+
+
+    info.GetReturnValue().Set(metrics);
+  }
+
+  NAN_MODULE_INIT(init) {
+    Nan::HandleScope scope;
+
+    Nan::Set(target, Nan::New("start").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(start)).ToLocalChecked());
+    Nan::Set(target, Nan::New("stop").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(stop)).ToLocalChecked());
+    Nan::Set(target, Nan::New("getMetrics").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(getMetrics)).ToLocalChecked());
+  }
+
+  NODE_MODULE(metrics, init)
+}

--- a/src/metrics/metrics.cc
+++ b/src/metrics/metrics.cc
@@ -42,7 +42,6 @@ namespace ao::metrics {
       Nan::Set(metrics, Nan::New("process").ToLocalChecked(), obj);
     }
 
-
     info.GetReturnValue().Set(metrics);
   }
 

--- a/src/metrics/process.cc
+++ b/src/metrics/process.cc
@@ -4,7 +4,7 @@
 #include "hdr_histogram.h"
 #include "process.h"
 
-namespace ao { namespace metrics { namespace gc {
+namespace ao { namespace metrics { namespace process {
 using namespace v8;
 
 bool enabled = true;

--- a/src/metrics/process.cc
+++ b/src/metrics/process.cc
@@ -4,7 +4,7 @@
 #include "hdr_histogram.h"
 #include "process.h"
 
-namespace ao::metrics::process {
+namespace ao { namespace metrics { namespace gc {
 using namespace v8;
 
 bool enabled = true;
@@ -48,6 +48,4 @@ bool getInterval(const v8::Local<v8::Object> obj) {
 }
 
 
-} // ao::metrics::eventloop
-
-
+}}} // ao::metrics::eventloop

--- a/src/metrics/process.cc
+++ b/src/metrics/process.cc
@@ -1,0 +1,53 @@
+#include <nan.h>
+#include <map>
+
+#include "hdr_histogram.h"
+#include "process.h"
+
+namespace ao::metrics::process {
+using namespace v8;
+
+bool enabled = true;
+uv_rusage_t prev_rusage;
+
+bool start() {
+  uv_getrusage(&prev_rusage);
+  enabled = true;
+  return true;
+}
+
+bool stop() {
+  enabled = false;
+  return true;
+}
+
+int64_t usec_time (uv_timeval_t t) {
+  return t.tv_sec * 1000 * 1000 + t.tv_usec;
+}
+
+//
+// get interval data
+//
+bool getInterval(const v8::Local<v8::Object> obj) {
+  if (!enabled) {
+    return false;
+  }
+
+  uv_rusage_t rusage;
+  uv_getrusage(&rusage);
+
+  const uint64_t user_time = usec_time(rusage.ru_utime) - usec_time(prev_rusage.ru_utime);
+  const uint64_t sys_time = usec_time(rusage.ru_stime) - usec_time(prev_rusage.ru_stime);
+
+  Nan::Set(obj, Nan::New("user").ToLocalChecked(), Nan::New<Number>(user_time));
+  Nan::Set(obj, Nan::New("system").ToLocalChecked(), Nan::New<Number>(sys_time));
+
+  prev_rusage = rusage;
+
+  return true;
+}
+
+
+} // ao::metrics::eventloop
+
+

--- a/src/metrics/process.h
+++ b/src/metrics/process.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <nan.h>
+
+namespace ao::metrics::process {
+  bool start();
+  bool stop();
+  bool getInterval(const v8::Local<v8::Object>);
+}

--- a/src/metrics/process.h
+++ b/src/metrics/process.h
@@ -2,7 +2,7 @@
 
 #include <nan.h>
 
-namespace ao { namespace metrics { namespace gc {
+namespace ao { namespace metrics { namespace process {
   bool start();
   bool stop();
   bool getInterval(const v8::Local<v8::Object>);

--- a/src/metrics/process.h
+++ b/src/metrics/process.h
@@ -2,8 +2,8 @@
 
 #include <nan.h>
 
-namespace ao::metrics::process {
+namespace ao { namespace metrics { namespace gc {
   bool start();
   bool stop();
   bool getInterval(const v8::Local<v8::Object>);
-}
+}}}

--- a/src/reporter.cc
+++ b/src/reporter.cc
@@ -184,7 +184,7 @@ Napi::Value send_metrics_core (Napi::Env env, Napi::Array metrics, uint64_t flag
     bool is_summary = false;
     std::string name;
     int64_t count;
-    double value;
+    double value = 0;
     bool add_host_tag = false;
 
     Napi::Value element = metrics[i];

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,9 +1,11 @@
-var bindings = require('../')
-const expect = require('chai').expect
+'use strict';
+
+const bindings = require('../');
+const expect = require('chai').expect;
 
 describe('addon.metadata', function () {
-  var metadata
-  var string
+  let metadata;
+  let string;
   const serviceKey = `${process.env.AO_TOKEN_PROD}:node-bindings-test`;
 
   it('should initialize oboe with only a service key', function () {
@@ -35,7 +37,7 @@ describe('addon.metadata', function () {
   })
 
   it('should set the sample flag', function () {
-    var md = metadata.toString()
+    const md = metadata.toString();
     metadata.setSampleFlagTo(1)
 
     // it shouldn't modify anything but the sample flag
@@ -45,7 +47,7 @@ describe('addon.metadata', function () {
   })
 
   it('should clear the sample flag', function () {
-    var md = metadata.toString()
+    const md = metadata.toString();
     metadata.setSampleFlagTo(0)
 
     expect(metadata.toString().slice(0, -2)).equal(md.slice(0, -2))
@@ -54,9 +56,9 @@ describe('addon.metadata', function () {
   })
 
   it('should set, clear, and return previous sample flag', function () {
-    var md = metadata.toString()
-    var onEntry = metadata.getSampleFlag()
-    var previous
+    const md = metadata.toString();
+    const onEntry = metadata.getSampleFlag();
+    let previous;
 
     previous = metadata.setSampleFlagTo(0)
     expect(metadata.toString().slice(0, -2)).equal(md.slice(0, -2))
@@ -73,13 +75,13 @@ describe('addon.metadata', function () {
   })
 
   it('should construct using metadata', function () {
-    var md = new bindings.Metadata(metadata)
+    const md = new bindings.Metadata(metadata);
     expect(md.toString()).equal(metadata.toString())
   })
 
   it('should construct using an event', function () {
-    var e = new bindings.Event(metadata)
-    var md = new bindings.Metadata(e)
+    const e = new bindings.Event(metadata);
+    const md = new bindings.Metadata(e);
     expect(md.toString()).equal(e.toString())
   })
 
@@ -94,9 +96,9 @@ describe('addon.metadata', function () {
   })
 
   it('should not construct from invalid metadata', function () {
-    var results = {}
-    var xtrace = string.slice()
-    var md = bindings.Metadata.fromString('0' + xtrace)
+    const results = {};
+    const xtrace = string.slice();
+    let md = bindings.Metadata.fromString('0' + xtrace);
     results['xtrace too long'] = md
     md = bindings.Metadata.fromString('1' + xtrace.slice(1))
     results['invalid version'] = md
@@ -106,19 +108,19 @@ describe('addon.metadata', function () {
     results['lowercase hex'] = md
 
     Object.keys(results).forEach(function (k) {
-      var correct = results[k] === undefined
+      const correct = results[k] === undefined;
       expect(correct).equal(true, k)
     })
 
   })
 
   it('should correctly test for the sample flag', function () {
-    var mdNoSample = bindings.Metadata.makeRandom()
-    var mdSample = bindings.Metadata.makeRandom(1)
+    const mdNoSample = bindings.Metadata.makeRandom();
+    const mdSample = bindings.Metadata.makeRandom(1);
     expect(bindings.Metadata.sampleFlagIsSet(mdNoSample)).equal(false)
     expect(bindings.Metadata.sampleFlagIsSet(mdSample)).equal(true)
 
-    var e = new bindings.Event(mdNoSample)
+    let e = new bindings.Event(mdNoSample);
     expect(bindings.Metadata.sampleFlagIsSet(e)).equal(false)
     expect(bindings.Metadata.sampleFlagIsSet(e.toString())).equal(false)
 
@@ -127,7 +129,7 @@ describe('addon.metadata', function () {
     expect(bindings.Metadata.sampleFlagIsSet(e.toString())).equal(true)
 
     // if there is an error it should return undefined.
-    var result = typeof bindings.Metadata.sampleFlagIsSet('')
+    const result = typeof bindings.Metadata.sampleFlagIsSet('');
     expect(result).equal('undefined')
   })
 
@@ -178,6 +180,6 @@ describe('addon.metadata', function () {
   })
 
   it('should not crash node when getting the prototype of an metadata instance', function () {
-    var p = Object.getPrototypeOf(bindings.Metadata.makeRandom())
+    Object.getPrototypeOf(bindings.Metadata.makeRandom())
   })
 })

--- a/test/reporter-metrics-memory.test.js
+++ b/test/reporter-metrics-memory.test.js
@@ -69,7 +69,7 @@ describe('reporter-metrics-memory', function () {
       .then(function () {
         finish1 = process.memoryUsage().rss;
         //console.log(start1, done1, start2, done2, finish1);
-        expect(finish1).lte(start2, `should execute ${checkCount} metrics with limited memory growth`);
+        expect(finish1).lte(start2, `should execute ${checkCount} metrics with limited rss growth`);
         gc(true);
       })
       .then(wait)
@@ -83,7 +83,7 @@ describe('reporter-metrics-memory', function () {
       .then(function () {
         const finish = process.memoryUsage().rss;
         //console.log(start1, done1, start2, done2, finish);
-        expect(finish).equal(finish1, 'should not change after first iteration');
+        expect(finish).equal(finish1, 'rss should not change after first iteration');
       })
   })
 
@@ -120,7 +120,6 @@ describe('reporter-metrics-memory', function () {
         start2 = process.memoryUsage().rss + checkCount;
         for (let i = checkCount; i > 0; i -= batchSize) {
           r.sendMetrics(metrics);
-          r.sendMetric('nothing.really', {value: i, testing: true});
         }
         done2 = process.memoryUsage().rss;
         gc(true);
@@ -129,7 +128,7 @@ describe('reporter-metrics-memory', function () {
       .then(function () {
         finish1 = process.memoryUsage().rss;
         //console.log(start1, done1, start2, done2, finish1);
-        expect(finish1).lte(start2, `should execute ${checkCount} metrics with limited memory growth`);
+        expect(finish1).lte(start2, `should execute ${checkCount} metrics with limited rss growth`);
         gc(true);
       })
       .then(wait)
@@ -143,7 +142,7 @@ describe('reporter-metrics-memory', function () {
       .then(function () {
         const finish = process.memoryUsage().rss;
         //console.log(start1, done1, start2, done2, finish);
-        expect(finish).equal(finish1, 'should not change after first iteration');
+        expect(finish).equal(finish1, 'rss should not change after first iteration');
       })
   })
 })

--- a/test/reporter-metrics-memory.test.js
+++ b/test/reporter-metrics-memory.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const aob = require('../');
+const r = aob.Reporter;
+const expect = require('chai').expect;
+
+const env = process.env;
+
+describe('reporter-metrics-memory', function () {
+  const serviceKey = `${env.AO_TOKEN_PROD}:node-bindings-test`;
+  const metrics = [];
+  const batchSize = 100;
+
+  before(function () {
+    const status = aob.oboeInit({serviceKey});
+    // oboeInit can return -1 for already initialized or 0 if succeeded.
+    // depending on whether this is run as part of a suite or standalone
+    // either result is valid.
+    if (status !== -1 && status !== 0) {
+      throw new Error('oboeInit() failed');
+    }
+
+    const ready = aob.Reporter.isReadyToSample(5000);
+    expect(ready).equal(1, `should connected to ${env.APPOPTICS_COLLECTOR} and ready`);
+
+    for (let i = 0; i < batchSize; i++) {
+      metrics.push({name: 'node.metrics.batch.test', value: i});
+    }
+  });
+
+  it('should sendMetric() without losing memory', function () {
+    this.timeout(20000);
+    const warmup =  500000;
+    const checkCount =  1000000;
+    // garbage collect if available
+    const gc = typeof global.gc === 'function' ? global.gc : () => null;
+
+    /* eslint-disable no-unused-vars */
+    let start1;
+    let done1;
+    let start2;
+    let done2;
+    let finish1;
+    /* eslint-enable no-unused-vars */
+
+    // allow the system to come to a steady state. garbage collection makes it
+    // hard to isolate memory losses.
+    return wait()
+      .then(function () {
+        start1 = process.memoryUsage().rss;
+        for (let i = warmup; i > 0; i--) {
+          r.sendMetric('nothing.really', {value: i});
+        }
+        done1 = process.memoryUsage().rss;
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        // now see if the code loses memory. if it's less than 1 byte per iteration
+        // then it's not losing memory for all practical purposes.
+        start2 = process.memoryUsage().rss + checkCount;
+        for (let i = checkCount; i > 0; i--) {
+          r.sendMetric('nothing.really', {value: i, testing: true});
+        }
+        done2 = process.memoryUsage().rss;
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        finish1 = process.memoryUsage().rss;
+        //console.log(start1, done1, start2, done2, finish1);
+        expect(finish1).lte(start2, `should execute ${checkCount} metrics with limited memory growth`);
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        for (let i = checkCount; i > 0; i--) {
+          r.sendMetric('nothing.really', {value: i, testing: true});
+        }
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        const finish = process.memoryUsage().rss;
+        //console.log(start1, done1, start2, done2, finish);
+        expect(finish).equal(finish1, 'should not change after first iteration');
+      })
+  })
+
+  it('should sendMetrics() without losing memory', function () {
+    this.timeout(20000);
+    const warmup = 500000;
+    const checkCount = 1000000;
+    // garbage collect if available
+    const gc = typeof global.gc === 'function' ? global.gc : () => null;
+
+    /* eslint-disable no-unused-vars */
+    let start1;
+    let done1;
+    let start2;
+    let done2;
+    let finish1;
+    /* eslint-enable no-unused-vars */
+
+    // allow the system to come to a steady state. garbage collection makes it
+    // hard to isolate memory losses.
+    return wait()
+      .then(function () {
+        start1 = process.memoryUsage().rss;
+        for (let i = warmup; i > 0; i -= batchSize) {
+          r.sendMetrics(metrics);
+        }
+        done1 = process.memoryUsage().rss;
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        // now see if the code loses memory. if it's less than 1 byte per iteration
+        // then it's not losing memory for all practical purposes.
+        start2 = process.memoryUsage().rss + checkCount;
+        for (let i = checkCount; i > 0; i -= batchSize) {
+          r.sendMetrics(metrics);
+          r.sendMetric('nothing.really', {value: i, testing: true});
+        }
+        done2 = process.memoryUsage().rss;
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        finish1 = process.memoryUsage().rss;
+        //console.log(start1, done1, start2, done2, finish1);
+        expect(finish1).lte(start2, `should execute ${checkCount} metrics with limited memory growth`);
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        for (let i = checkCount; i > 0; i -= batchSize) {
+          r.sendMetrics(metrics);
+        }
+        gc(true);
+      })
+      .then(wait)
+      .then(function () {
+        const finish = process.memoryUsage().rss;
+        //console.log(start1, done1, start2, done2, finish);
+        expect(finish).equal(finish1, 'should not change after first iteration');
+      })
+  })
+})
+
+function wait (ms = 100) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/test/reporter-metrics.test.js
+++ b/test/reporter-metrics.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const aob = require('../');
+const expect = require('chai').expect;
+
+const env = process.env;
+
+describe('aob.Reporter.sendMetrics()', function () {
+  const serviceKey = `${env.AO_TOKEN_PROD}:node-bindings-test`;
+
+  before(function () {
+    const status = aob.oboeInit({serviceKey});
+    // oboeInit can return -1 for already initialized or 0 if succeeded.
+    // depending on whether this is run as part of a suite or standalone
+    // either result is valid.
+    if (status !== -1 && status !== 0) {
+      throw new Error('oboeInit() failed');
+    }
+
+    const ready = aob.Reporter.isReadyToSample(5000);
+    expect(ready).equal(1, `should connected to ${env.APPOPTICS_COLLECTOR} and ready`);
+  })
+
+  it('should handle an array of zero length', function () {
+    const status = aob.Reporter.sendMetrics([]);
+    expect(status).deep.equal({errors: []});
+  })
+
+  it('should require an array argument', function () {
+    const args = [
+      {i: 'am not an array'},
+      'nor am i',
+      0,
+      false,
+      Symbol('xyzzy'),
+    ];
+
+    for (let i = 0; i < args.length; i++) {
+      function test () {
+        aob.Reporter.sendMetrics(args[i]);
+      }
+      expect(test).throws('invalid signature for sendMetrics()');
+    }
+  })
+
+  it('should return bad metrics', function () {
+    const x = Symbol('expected-error');
+    const metrics = [
+      {count: 1, [x]: 2},
+      {name: 'gc.count', count: 'x', [x]: 3},
+      {name: 'gc.count', count: -1, [x]: 4},
+      {name: 'gc.count', count: 1, value: 'x', [x]: 5},
+      {name: 'gc.count', count: 1, value: 3.141592654, tags: 'i am not an object', [x]: 6},
+    ];
+
+    const results = aob.Reporter.sendMetrics(metrics);
+    expect(results).not.property('correct');
+    expect(results).property('errors').an('array');
+    expect(results.errors.length).equal(metrics.length);
+
+    for (let i = 0; i < metrics.length; i++) {
+      const error = results.errors[i];
+      const expectedError = error.metric[x];
+      delete error.metric[x];
+      expect(error.code).equal(expectedError);
+      expect(error.metric).deep.equal(metrics[i]);
+    }
+  });
+
+  it('should handle correct metrics', function () {
+    const metrics = [
+      {name: 'testing.node.abc', count: 1},
+      {name: 'testing.node.def', count: 1, value: 42},
+      {name: 'testing.node.xyz', count: 1, value: 84, addHostTag: true},
+      {name: 'testing.node.xyz', count: 1, value: 2.71828, addHostTag: false},
+      {name: 'testing.node.gc', count: 4, tags: {bruce: 'test', macnaughton: 'name'}},
+      {name: 'testing.node.bool', count: 1, addHostTag: 1},
+      {name: 'testing.node.bool', count: 1, addHostTag: ''},
+    ];
+    const results = aob.Reporter.sendMetrics(metrics, {testing: true});
+    expect(results).property('correct').an('array');
+    expect(results.correct.length).equal(metrics.length);
+    expect(results).property('errors').an('array');
+    expect(results.errors.length).equal(0);
+
+    for (let i = 0; i < results.correct.length; i++) {
+      const metric = results.correct[i];
+      const expected = Object.assign({}, metrics[i], {addHostTag: !!metrics[i].addHostTag});
+      expect(metric).deep.equal(expected);
+    }
+  });
+
+  it.skip('should send metrics without losing memory', function (done) {
+    this.timeout(5000);
+    const warmup =  1000000;
+    const checkCount =  1000000;
+    // garbage collect if available
+    const gc = typeof global.gc === 'function' ? global.gc : () => null;
+
+    // allow the system to come to a steady state. garbage collection makes it
+    // hard to isolate memory losses.
+    const start1 = process.memoryUsage().rss;
+    for (let i = warmup; i > 0; i--) {
+      r.sendMetric('nothing.really', {value: i, testing: true});
+    }
+
+    gc();
+
+    // now see if the code loses memory. if it's less than 1 byte per iteration
+    // then it's not losing memory for all practical purposes.
+    const start2 = process.memoryUsage().rss + checkCount;
+    for (let i = checkCount; i > 0; i--) {
+      r.sendMetric('nothing.really', {value: i, testing: true});
+    }
+
+    gc();
+
+    // give garbage collection a window to kick in.
+    setTimeout(function () {
+      const finish = process.memoryUsage().rss;
+      expect(finish).lte(start2, `should execute ${checkCount} metrics without memory growth`);
+      done()
+    }, 250)
+
+    gc();
+  })
+})

--- a/test/reporter-metrics.test.js
+++ b/test/reporter-metrics.test.js
@@ -49,7 +49,7 @@ describe('reporter-metrics', function () {
       'not an object',
       [],
       {count: 1, [x]: 'must have string name'},
-      {name: 'gc.count', count: 'x', [x]: 'must have numeric count'},
+      {name: 'gc.count', count: 'x', [x]: 'count must be a number'},
       {name: 'gc.count', count: -1, [x]: 'count must be greater than 0'},
       {name: 'gc.count', count: 1, value: 'x', [x]: 'summary value must be numeric'},
       {name: 'gc.count', count: 1, value: 3.141592654, tags: 'i am not an object', [x]: 'tags must be plain object'},
@@ -78,6 +78,7 @@ describe('reporter-metrics', function () {
 
   it('should handle correct metrics', function () {
     const metrics = [
+      {name: 'testing.node.123'},
       {name: 'testing.node.abc', count: 1},
       {name: 'testing.node.def', count: 1, value: 42},
       {name: 'testing.node.xyz', count: 1, value: 84, addHostTag: true},
@@ -94,7 +95,9 @@ describe('reporter-metrics', function () {
 
     for (let i = 0; i < results.correct.length; i++) {
       const metric = results.correct[i];
-      const expected = Object.assign({}, metrics[i], {addHostTag: !!metrics[i].addHostTag});
+      const defaults = {count: 1};
+      const addedOptions = {addHostTag: !!metrics[i].addHostTag};
+      const expected = Object.assign(defaults, metrics[i], addedOptions);
       expect(metric).deep.equal(expected);
     }
   });

--- a/test/reporter-metrics.test.js
+++ b/test/reporter-metrics.test.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect;
 
 const env = process.env;
 
-describe('aob.Reporter.sendMetrics()', function () {
+describe('reporter-metrics', function () {
   const serviceKey = `${env.AO_TOKEN_PROD}:node-bindings-test`;
 
   before(function () {
@@ -98,39 +98,4 @@ describe('aob.Reporter.sendMetrics()', function () {
       expect(metric).deep.equal(expected);
     }
   });
-
-  it.skip('should send metrics without losing memory', function (done) {
-    this.timeout(5000);
-    const warmup =  1000000;
-    const checkCount =  1000000;
-    // garbage collect if available
-    const gc = typeof global.gc === 'function' ? global.gc : () => null;
-
-    // allow the system to come to a steady state. garbage collection makes it
-    // hard to isolate memory losses.
-    const start1 = process.memoryUsage().rss;
-    for (let i = warmup; i > 0; i--) {
-      r.sendMetric('nothing.really', {value: i, testing: true});
-    }
-
-    gc();
-
-    // now see if the code loses memory. if it's less than 1 byte per iteration
-    // then it's not losing memory for all practical purposes.
-    const start2 = process.memoryUsage().rss + checkCount;
-    for (let i = checkCount; i > 0; i--) {
-      r.sendMetric('nothing.really', {value: i, testing: true});
-    }
-
-    gc();
-
-    // give garbage collection a window to kick in.
-    setTimeout(function () {
-      const finish = process.memoryUsage().rss;
-      expect(finish).lte(start2, `should execute ${checkCount} metrics without memory growth`);
-      done()
-    }, 250)
-
-    gc();
-  })
 })

--- a/test/reporter-metrics.test.js
+++ b/test/reporter-metrics.test.js
@@ -87,7 +87,9 @@ describe('reporter-metrics', function () {
       {name: 'testing.node.bool', count: 1, addHostTag: 1},
       {name: 'testing.node.bool', count: 1, addHostTag: ''},
     ];
-    const results = aob.Reporter.sendMetrics(metrics, {testing: true});
+    // make this a noop so that if run following the memory tests that it won't fail
+    // due to the memory tests having overloaded oboe.
+    const results = aob.Reporter.sendMetrics(metrics, {testing: true, noop: true});
     expect(results).property('correct').an('array');
     expect(results.correct.length).equal(metrics.length);
     expect(results).property('errors').an('array');

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -1,10 +1,12 @@
-var bindings = require('../')
-const expect = require('chai').expect
+'use strict';
+
+const bindings = require('../');
+const expect = require('chai').expect;
 
 const env = process.env;
 
 describe('addon.reporter', function () {
-  let r
+  let r;
   if (typeof bindings.Reporter === 'function') {
     r = new bindings.Reporter()
   } else {
@@ -20,7 +22,7 @@ describe('addon.reporter', function () {
 
 
   it('should initialize oboe with only a service key', function () {
-    const status = bindings.oboeInit({serviceKey})
+    const status = bindings.oboeInit({serviceKey});
     // kind of funky but -1 is already initialized, 0 is ok. mocha runs
     // multiple tests in one process so the result is 0 if run standalone
     // but -1 on all but the first if run as a suite.
@@ -36,19 +38,19 @@ describe('addon.reporter', function () {
   it('should check if ready to sample', function () {
     // wait 5 seconds max. This will fail if not using
     // a real collector (collector or collector-stg).appoptics.com
-    var ready = r.isReadyToSample(5000)
+    const ready = r.isReadyToSample(5000);
     expect(ready).be.a('number')
 
     expect(ready).equal(1, `${env.APPOPTICS_COLLECTOR} should be ready`)
   })
 
   it('should send a generic span', function () {
-    var customName = 'this-is-a-name'
-    var domain = 'bruce.com'
+    const customName = 'this-is-a-name';
+    const domain = 'bruce.com';
 
-    var finalTxName = r.sendNonHttpSpan({
+    let finalTxName = r.sendNonHttpSpan({
       duration: 1001
-    })
+    });
     expect(finalTxName).equal('unknown')
 
     finalTxName = r.sendNonHttpSpan({
@@ -71,18 +73,18 @@ describe('addon.reporter', function () {
   })
 
   it('should send an HTTP span', function () {
-    var customName = 'this-is-a-name'
-    var domain = 'bruce.com'
-    var url = '/api/todo'
-    var status = 200
-    var method = 'GET'
+    const customName = 'this-is-a-name';
+    const domain = 'bruce.com';
+    const url = '/api/todo';
+    const status = 200;
+    const method = 'GET';
 
-    var finalTxName = r.sendHttpSpan({
+    let finalTxName = r.sendHttpSpan({
       url: url,
       status: status,
       method: method,
       duration: 1111
-    })
+    });
     expect(finalTxName).equal(url)
 
     finalTxName = r.sendHttpSpan({
@@ -108,7 +110,8 @@ describe('addon.reporter', function () {
   })
 
   it('should not crash node getting the prototype of a reporter instance', function () {
-    var p = Object.getPrototypeOf(r)
+    // eslint-disable-next-line no-unused-vars
+    const p = Object.getPrototypeOf(r);
   })
 
   it('should throw errors for bad arguments to sendMetric', function () {
@@ -124,12 +127,10 @@ describe('addon.reporter', function () {
       {args: ['name', {tags: 11}], text: 'non-object tags'},
     ];
 
-    for (let t of tests) {
-      const options = Object.assign({}, defaultOptions, t.options)
+    for (const t of tests) {
       const fn = () => r.sendMetric(...t.args);
       expect(fn, `${t.text} should throw`).throws(TypeError);
     }
-
   })
 
   it('should send metrics without losing memory', function (done) {
@@ -164,8 +165,6 @@ describe('addon.reporter', function () {
       done()
     }, 250)
 
-    if (typeof global.gc === 'function') {
-      global.gc();
-    }
+    gc();
   })
 })

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -14,12 +14,6 @@ describe('addon.reporter', function () {
   }
   const serviceKey = `${env.AO_TOKEN_PROD}:node-bindings-test`;
 
-  beforeEach(function () {
-    if (this.currentTest.title === 'should execute without losing memory') {
-
-    }
-  })
-
 
   it('should initialize oboe with only a service key', function () {
     const status = bindings.oboeInit({serviceKey});

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -115,8 +115,6 @@ describe('addon.reporter', function () {
   })
 
   it('should throw errors for bad arguments to sendMetric', function () {
-    const defaultOptions = {noop: true};
-
     const tests = [
       {args: [], text: 'no args'},
       {args: [1], text: 'non-string metric name'},
@@ -131,40 +129,5 @@ describe('addon.reporter', function () {
       const fn = () => r.sendMetric(...t.args);
       expect(fn, `${t.text} should throw`).throws(TypeError);
     }
-  })
-
-  it('should send metrics without losing memory', function (done) {
-    this.timeout(5000);
-    const warmup =  1000000;
-    const checkCount =  1000000;
-    // garbage collect if available
-    const gc = typeof global.gc === 'function' ? global.gc : () => null;
-
-    // allow the system to come to a steady state. garbage collection makes it
-    // hard to isolate memory losses.
-    const start1 = process.memoryUsage().rss;
-    for (let i = warmup; i > 0; i--) {
-      r.sendMetric('nothing.really', {value: i, testing: true});
-    }
-
-    gc();
-
-    // now see if the code loses memory. if it's less than 1 byte per iteration
-    // then it's not losing memory for all practical purposes.
-    const start2 = process.memoryUsage().rss + checkCount;
-    for (let i = checkCount; i > 0; i--) {
-      r.sendMetric('nothing.really', {value: i, testing: true});
-    }
-
-    gc();
-
-    // give garbage collection a window to kick in.
-    setTimeout(function () {
-      const finish = process.memoryUsage().rss;
-      expect(finish).lte(start2, `should execute ${checkCount} metrics without memory growth`);
-      done()
-    }, 250)
-
-    gc();
   })
 })

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -107,21 +107,4 @@ describe('addon.reporter', function () {
     // eslint-disable-next-line no-unused-vars
     const p = Object.getPrototypeOf(r);
   })
-
-  it('should throw errors for bad arguments to sendMetric', function () {
-    const tests = [
-      {args: [], text: 'no args'},
-      {args: [1], text: 'non-string metric name'},
-      {args: ['name', 'a'], text: 'non-object options'},
-      {args: ['name', []], text: 'array-object options'},
-      {args: ['name', {value: 'x'}], text: 'non-numeric value'},
-      {args: ['name', {tags: []}], text: 'array-object tags'},
-      {args: ['name', {tags: 11}], text: 'non-object tags'},
-    ];
-
-    for (const t of tests) {
-      const fn = () => r.sendMetric(...t.args);
-      expect(fn, `${t.text} should throw`).throws(TypeError);
-    }
-  })
 })

--- a/test/settings.test.js
+++ b/test/settings.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const bindings = require('..')
 const expect = require('chai').expect
 
@@ -48,7 +50,7 @@ describe('addon.settings', function () {
   })
 
   it('should not throw when setting invalid sample rate', function () {
-    var threw = false
+    let threw = false;
     try {
       bindings.Settings.setDefaultSampleRate(-1)
       bindings.Settings.setDefaultSampleRate(bindings.MAX_SAMPLE_RATE + 1)
@@ -60,7 +62,7 @@ describe('addon.settings', function () {
   })
 
   it('should handle bad sample rates correctly', function () {
-    var rateUsed
+    let rateUsed;
     rateUsed = bindings.Settings.setDefaultSampleRate(-1)
     expect(rateUsed).equal(0)
     rateUsed = bindings.Settings.setDefaultSampleRate(bindings.MAX_SAMPLE_RATE + 1)
@@ -76,8 +78,8 @@ describe('addon.settings', function () {
   })
 
   it('should tell us that a non-traced xtrace doesn\'t need to be sampled', function () {
-    var md = bindings.Metadata.makeRandom(0)
-    var settings = bindings.Settings.getTraceSettings({xtrace: md.toString()})
+    const md = bindings.Metadata.makeRandom(0);
+    const settings = bindings.Settings.getTraceSettings({xtrace: md.toString()});
 
     expect(settings).property('status', -1)       // -1 means non-sampled xtrace
   })
@@ -85,15 +87,15 @@ describe('addon.settings', function () {
   it('should get verification that a request should be sampled', function (done) {
     bindings.Settings.setTracingMode(bindings.TRACE_ALWAYS)
     bindings.Settings.setDefaultSampleRate(bindings.MAX_SAMPLE_RATE)
-    var event = new bindings.Event(bindings.Metadata.makeRandom(1));
-    var metadata = event.getMetadata()
+    const event = new bindings.Event(bindings.Metadata.makeRandom(1));
+    const metadata = event.getMetadata();
     metadata.setSampleFlagTo(1)
-    var xid = metadata.toString();
-    var counter = 20
+    const xid = metadata.toString();
+    let counter = 20
     // poll to give time for the SSL connection to complete. it should have
     // been waited on in before() but it's possible for the connection to break.
-    var id = setInterval(function() {
-      var settings = bindings.Settings.getTraceSettings({xtrace: xid})
+    const id = setInterval(function () {
+      const settings = bindings.Settings.getTraceSettings({xtrace: xid})
       if (--counter <= 0 || typeof settings === 'object' && settings.source !== 2) {
         clearInterval(id)
         expect(settings).property('status', 0);


### PR DESCRIPTION
- new function send_metrics_core() - used by new sendMetrics() and legacy sendMetric()
- new test/reporter-metrics-memory.test.js file because memory loss tests are relatively slow
- new test/reporter-metrics.test.js to send sendMetrics() call.
- eslint conformance