### PR TITLE
11.0.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "module_name": "apm_bindings",
     "module_path": "./dist/{node_napi_label}",
     "staging_host": "https://rc-files-t2.s3-us-west-2.amazonaws.com",
-    "production_host": "https://files.appoptics.com.s3.amazonaws.com",
+    "production_host": "https://appoptics-binaries.s3.amazonaws.com",
     "host": "",
     "remote_path": "./nodejs/bindings",
     "package_name": "{module_name}-v{version}-{node_abi}-{node_napi_label}-{libc}-{arch}.tar.gz"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "!darwin",
     "!win32"
   ],
-  "version": "11.0.0-rc1",
+  "version": "11.0.0-rc2",
   "appoptics": {
     "version-suffix": "lambda-1"
   },
@@ -24,7 +24,7 @@
     "module_name": "apm_bindings",
     "module_path": "./dist/{node_napi_label}",
     "staging_host": "https://rc-files-t2.s3-us-west-2.amazonaws.com",
-    "production_host": "https://apm-bruce-production.s3.amazonaws.com",
+    "production_host": "https://files.appoptics.com.s3.amazonaws.com",
     "host": "",
     "remote_path": "./nodejs/bindings",
     "package_name": "{module_name}-v{version}-{node_abi}-{node_napi_label}-{libc}-{arch}.tar.gz"


### PR DESCRIPTION
- requires that the repo secrets:
PROD_AWS_ACCESS_KEY_ID
PROD_AWS_SECRET_ACCESS_KEY
be updated