### PR TITLE
AO-19439 lambda version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "version": "11.0.0",
   "appoptics": {
-    "version-suffix": "lambda-2"
+    "version-suffix": "lambda-1"
   },
   "description": "Bindings for appoptics-apm with pre-built support",
   "author": "Bruce A. MacNaughton <bruce.macnaughton@solarwinds.com>",


### PR DESCRIPTION
I think the intention of these lambda version suffixes is to reset to 1 for each agent/bindings version, and only increment if we needed to release a new lambda layer off of the same agent/bindings version.

The current GA lambda layer:
> description: apm v9.1.0-lambda-2, bindings v10.0.0-lambda-1, auto v1.0.0-lambda-1

The RC lambda layer versions will be:
> description: apm v10.0.1-lambda-1, bindings v11.0.0-lambda-1, auto v1.0.0