### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-3

### DIFF
--- a/.github/docker-node/14-centos8.Dockerfile
+++ b/.github/docker-node/14-centos8.Dockerfile
@@ -21,3 +21,4 @@ RUN source $NVM_DIR/nvm.sh \
 # add node and npm to path so the commands are available
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/.github/docker-node/14-centos8.Dockerfile
+++ b/.github/docker-node/14-centos8.Dockerfile
@@ -21,4 +21,3 @@ RUN source $NVM_DIR/nvm.sh \
 # add node and npm to path so the commands are available
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-

--- a/.github/workflows/docker-node.yml
+++ b/.github/workflows/docker-node.yml
@@ -1,0 +1,52 @@
+name: Build Docker Images
+
+on:
+  push:
+    paths:
+      - '.github/docker-node/*.Dockerfile'
+
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    name: Build docker images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: 
+        tag: [
+          '10-alpine3.9-build',
+          '10-centos7-build',
+          '10-amazonlinux2',
+          '10-centos7',
+          '10-centos8',
+          '12-alpine3.9-build',
+          '12-centos7-build',
+          '12-amazonlinux2',
+          '12-centos7',
+          '12-centos8',
+          '14-alpine3.10-build',
+          '14-centos7-build',
+          '14-amazonlinux2',
+          '14-centos7',
+          '14-centos8'
+        ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./.github/docker-node/
+          file: ./.github/docker-node/${{ matrix.tag }}.Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/node:${{ matrix.tag }}


### PR DESCRIPTION
  This Pull Request is the **3rd** in a series of Pull Requests to refactor GitHub Actions.

  The first commit (d83014866a74c581cb89edb741cd86fb1c36f35a) added a workflow that builds and publishes images to GitHub Container Registry (ghcr.io). Images are scoped to repo and tagged.


  When run, the workflow creates a ["single" package](https://github.com/orgs/appoptics/packages) named `node` scoped to `appoptics/appoptics-bindings-node` (the repo). Package has [multiple tagged images](https://github.com/appoptics/appoptics-bindings-node/pkgs/container/appoptics-bindings-node%2Fnode) for each of the dockerfiles from which it was built. For example, the image created from a file named `10-centos7-build.Dockerfile` has a `10-centos7-build` tag and can pulled from `ghcr.io/appoptics/appoptics-bindings-node/node:10-centos7-build`.  Since this repo is public, the images are also public.

 Workflow is triggered by any change to the Dockerfiles in the `docker-node` directory and can also be triggered manually. Current implementation has tags listed in the YAML file. 

 The second commit (fb57e06c2f1817c2129da7e2fd35493509009d84) is an "initialization trigger" for the workflow. The GitHub Actions tab only provide links to workflows that are either on master (not this one) or have run before (not this one). After the "initialization trigger" commit, as the workflow "has run before", it can also be manually triggered.