### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-4

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,57 @@
+name: Single Build & Test (Push)
+
+# workflow is for a branch push only and ignores master.
+# push to master (which is also pull requet merge) has a more elaborate workflow to run
+# github repo is configured with branch protection on master.
+on: 
+  push:
+    branches-ignore:
+      - 'master'
+
+  workflow_dispatch:
+    inputs: 
+      node:
+        required: false
+        description: 'A node version (e.g 10.16.0)'
+        default: '14' # TODO: update to 16 when support is added
+
+jobs:
+  build-single-test:
+    runs-on: ubuntu-latest # environment job will run in
+
+    env:
+      # TODO: move to staging when AO-20147
+      AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }} 
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Setup Node ${{ github.event.inputs.node || github.event.inputs.node.default }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ github.event.inputs.node || github.event.inputs.node.default }}
+
+      - name: Show Info
+        run: |
+          whoami
+          id
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+          pwd
+          ls -al
+
+      # must install specific dependencies before a build
+      # can't call npm install. doing so may fallback-to-build if package has yet to be published (double build)
+      # use npm workaround specifying a package name to bypass install script in package.json
+      - name: NPM Install dependencies
+        run: npm install linux-os-info --unsafe-perm
+
+      # runs: node setup-liboboe.js && node-pre-gyp install --build-from-source
+      - name: NPM Install with Rebuild from source
+        run: npm run rebuild
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: Single Build & Test (Push)
 
 # workflow is for a branch push only and ignores master.
-# push to master (which is also pull requet merge) has a more elaborate workflow to run
+# push to master (which is also pull request merge) has a more elaborate workflow to run
 # github repo is configured with branch protection on master.
 on: 
   push:
@@ -27,10 +27,10 @@ jobs:
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
-      - name: Setup Node ${{ github.event.inputs.node || github.event.inputs.node.default }}
+      - name: Setup Node ${{ github.event.inputs.node || '14' }}
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ github.event.inputs.node || github.event.inputs.node.default }}
+          node-version: ${{ github.event.inputs.node || '14' }}
 
       - name: Show Info
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,16 +32,12 @@ jobs:
         with:
           node-version: ${{ github.event.inputs.node || '14' }}
 
-      - name: Show Info
+      - name: Show Environment Info
         run: |
-          whoami
-          id
           printenv
           node --version
           npm --version 
           cat /etc/os-release
-          pwd
-          ls -al
 
       # must install specific dependencies before a build
       # can't call npm install. doing so may fallback-to-build if package has yet to be published (double build)


### PR DESCRIPTION
This Pull Request is the **4th** in a series of Pull Requests to refactor GitHub Actions.

The single commit (b0d6d26b974971419b5f4790aa82751a52c92470) added a workflow used for development.

Usage:
* Push to master is disabled by branch protection.
* Push to branch will trigger push.yml. 
* Workflow will:
  - Build the code pushed on the runner with node 14 (latest currently supported).
  - Run the tests against the build.
* Workflow simply confirms code is not "broken".
* Manual trigger supported. Enables to select version number (e.g. `10.16.0`) to build code on.

Diagram:

```
push to branch ──► ┌───────────────────┐ ─► ─► ─► ─► ─►
                   │Single Build & Test│ contained build
manual (image?) ─► └───────────────────┘ ◄── ◄── ◄── ◄──
```

Todos:
  1. Update default node version to 16 when support is added in AO-20084.
  2. Move to tests to work against staging collector when AO-20147 is implemented.

Notes:
  * Job steps include an optional step (Show Info) that runs a set of commands to log information that was found useful during the dev process. Same step is to be included in all future workflows. Thus tweaks expected and suggestions welcomed.
  * Suggestions for additional informational steps are also welcomed.


