### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-6

### DIFF
--- a/.github/config/build-group.json
+++ b/.github/config/build-group.json
@@ -1,0 +1,23 @@
+
+{
+  "include": [
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-alpine3.9-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-alpine3.9-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-alpine3.10-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-centos7-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-centos7-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos7-build"
+    }
+  ]
+}

--- a/.github/config/docker-node.json
+++ b/.github/config/docker-node.json
@@ -1,0 +1,49 @@
+{
+  "include": [
+    {
+      "tag": "10-alpine3.9-build",
+    },
+    {
+      "tag": "10-centos7-build",
+    },
+    {
+      "tag": "10-amazonlinux2",
+    },
+    {
+      "tag": "10-centos7",
+    },
+    {
+      "tag": "10-centos8",
+    },
+    {
+      "tag": "12-alpine3.9-build",
+    },
+    {
+      "tag": "12-centos7-build",
+    },
+    {
+      "tag": "12-amazonlinux2",
+    },
+    {
+      "tag": "12-centos7",
+    },
+    {
+      "tag": "12-centos8",
+    },
+    {
+      "tag": "14-alpine3.10-build",
+    },
+    {
+      "tag": "14-centos7-build",
+    },
+    {
+      "tag": "14-amazonlinux2",
+    },
+    {
+      "tag": "14-centos7",
+    },
+    {
+      "tag": "14-centos8",
+    }
+  ]
+}

--- a/.github/config/fallback-group.json
+++ b/.github/config/fallback-group.json
@@ -1,0 +1,22 @@
+{
+  "include": [
+    {
+      "image": "node:10-buster"
+    },
+    {
+      "image": "node:10-stretch"
+    },
+    {
+      "image": "node:12-buster"
+    },
+    {
+      "image": "node:12-stretch"
+    },
+    {
+      "image": "node:14-buster"
+    },
+    {
+      "image": "node:14-stretch"
+    }
+  ]
+}

--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -1,0 +1,85 @@
+{
+  "include": [
+    {
+      "image": "node:10-buster-slim"
+    },
+    {
+      "image": "node:10-stretch-slim"
+    },
+    {
+      "image": "node:10-alpine3.9"
+    },
+    {
+      "image": "node:10-alpine3.10"
+    },
+    {
+      "image": "node:10-alpine3.11"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-amazonlinux2"
+    },
+    {
+      "image": "node:12-buster-slim"
+    },
+    {
+      "image": "node:12-stretch-slim"
+    },
+    {
+      "image": "node:12-alpine3.9"
+    },
+    {
+      "image": "node:12-alpine3.10"
+    },
+    {
+      "image": "node:12-alpine3.11"
+    },
+    {
+      "image": "node:12-alpine3.12"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-amazonlinux2"
+    },
+    {
+      "image": "node:14-buster-slim"
+    },
+    {
+      "image": "node:14-stretch-slim"
+    },
+    {
+      "image": "node:14-alpine3.10"
+    },
+    {
+      "image": "node:14-alpine3.11"
+    },
+    {
+      "image": "node:14-alpine3.12"
+    },
+    {
+      "image": "node:14-alpine3.13"
+    },
+    {
+      "image": "node:14-alpine3.14"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-amazonlinux2"
+    }
+  ]
+}

--- a/.github/scripts/matrix-from-json.sh
+++ b/.github/scripts/matrix-from-json.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+path_to_file="$1"
+
+# escape human readable multi line json
+# to format usable by github fromJSON.
+# see https://github.com/actions/toolkit/issues/403
+# and https://github.com/actions/toolkit/blob/master/packages/core/src/command.ts#L92
+JSON=$(cat "$path_to_file")
+JSON="${JSON//'%'/'%25'}"
+JSON="${JSON//$'\n'/'%0A'}"
+JSON="${JSON//$'\r'/'%0D'}"
+# enable the JSON to use any environment var
+# replace the = sign with a space and turn into array
+for env_var in $(printenv); do
+  read -ra arr <<< "${env_var//=/ }"
+  JSON="${JSON//\$${arr[0]}/"${arr[1]}"}"
+done
+
+# return a value
+echo "::set-output name=matrix::$JSON"

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -156,10 +156,7 @@ jobs:
 
       # *** IMPORTANT: 
       # always include --s3_host flag regardless of node-pre-gyp defaults.
-      # node-pre-gyp can't publish over existing version, thus always attempt unpublished of current in staging bucket
-      - name: Clear Staging for version
-        run: npx node-pre-gyp unpublish --s3_host=staging
-
+      # node-pre-gyp can't publish over existing version, but bucket was cleared at beginning of workflow
       - name: Publish Package to Staging
         run: npx node-pre-gyp publish --s3_host=staging
 

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -1,0 +1,214 @@
+name: Fallback Install, Build & Package & Prebuilt Install (Merge)
+
+on: 
+  push: 
+    branches: 
+      # triggered by pull request approval triggers which is a merge to default branch
+      - master
+
+  workflow_dispatch:
+    inputs: 
+      target-test:
+        required: false
+        description: 'Run Tests on Target & Fallback Groups? (type: yes)'
+        default: false
+
+jobs:
+  # both build-group-unpublish and  build-group-publish "needs" this job
+  load-build-group:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+      # build with the lowest versions of the OSes supported so the glibc/musl versions are the oldest/most compatible. 
+      # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
+    - name: Load build group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
+
+  build-group-unpublish:
+    runs-on: ubuntu-latest 
+    needs: load-build-group
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+    container:
+        image:  ${{ matrix.image }}
+
+    env: 
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      # must install specific dependencies before a build
+      # can't call npm install. doing so may fallback-to-build if package has yet to be published (double build)
+      # use npm workaround specifying a package name to bypass install script in package.json
+      - name: NPM Install dependencies
+        run: npm install linux-os-info --unsafe-perm
+
+      - name: Clear Staging for version
+        run: npx node-pre-gyp unpublish --s3_host=staging
+
+  load-fallback-group:
+    runs-on: ubuntu-latest
+    needs: build-group-unpublish
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+      # contains images that are able to build "out of the box"
+    - name: Load target group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/fallback-group.json
+
+  fallback-group-install:
+    runs-on: ubuntu-latest
+    needs: load-fallback-group
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.load-fallback-group.outputs.matrix)}}
+    container:
+        image: ${{ matrix.image }}
+
+    env:
+      # TODO: move to staging when AO-20147
+      AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      # the staging bucket has been cleared
+      # install of package will fallback to build from source
+      - name: NPM Install (to fallback)
+        run: npm install --unsafe-perm --s3_host=staging
+
+      - name: Check Artifacts
+        run: ls ./dist/napi-v*/apm_bindings.node && ls ./dist/napi-v*/ao_metrics.node
+
+      - name: Run tests
+        run: npm test
+        if: ${{ github.event.inputs.target-test }}
+
+  build-group-publish:
+    runs-on: ubuntu-latest 
+    needs: [load-build-group, fallback-group-install]
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+    container:
+        image:  ${{ matrix.image }}
+
+    env: 
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      # must install specific dependencies before a build
+      # can't call npm install. doing so may fallback-to-build if package has yet to be published (double build)
+      # use npm workaround specifying a package name to bypass install script in package.json
+      - name: NPM Install dependencies
+        run: npm install linux-os-info --unsafe-perm
+
+      # must setup libobo before build
+      # node-pre-gyp rebuild runs "clean" and "build" at once.
+      # it is mapped to `node-gyp rebuild` which internally means "clean + configure + build" and triggers a full recompile
+      - name: Build
+        run: |
+          node setup-liboboe.js
+          npx node-pre-gyp rebuild
+
+      # artifacts are at:build/stage/nodejs/bindings/
+      - name: Package
+        run: npx node-pre-gyp package # requires clean rebuild
+
+      # *** IMPORTANT: 
+      # always include --s3_host flag regardless of node-pre-gyp defaults.
+      # node-pre-gyp can't publish over existing version, thus always attempt unpublished of current in staging bucket
+      - name: Clear Staging for version
+        run: npx node-pre-gyp unpublish --s3_host=staging
+
+      - name: Publish Package to Staging
+        run: npx node-pre-gyp publish --s3_host=staging
+
+  load-prebuilt-group:
+    runs-on: ubuntu-latest
+    needs: build-group-publish
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+      # contains images that are unable to build "out of the box" and will install prebuilt
+    - name: Load target group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/prebuilt-group.json
+
+  prebuilt-group-install:
+    runs-on: ubuntu-latest 
+    needs: load-prebuilt-group
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.load-prebuilt-group.outputs.matrix)}}
+    container:
+        image: ${{ matrix.image }}
+
+    env:
+      # TODO: move to staging when AO-20147
+      AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      # *** IMPORTANT: by default our package is installed from production bucket as defined in package.json. 
+      # to test current build pass --s3_host="staging"
+      - name: NPM Install Staging
+        run: npm install --unsafe-perm --s3_host=staging
+
+      - name: Check Artifacts
+        run: ls ./dist/napi-v*/apm_bindings.node && ls ./dist/napi-v*/ao_metrics.node
+
+      - name: Run tests
+        run: npm test
+        if: ${{ github.event.inputs.target-test }}

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -39,8 +39,8 @@ jobs:
         image:  ${{ matrix.image }}
 
     env: 
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout ${{ github.ref }}
@@ -122,8 +122,8 @@ jobs:
         image:  ${{ matrix.image }}
 
     env: 
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - name: Checkout ${{ github.ref }}

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -53,8 +53,8 @@ jobs:
           npm --version 
           cat /etc/os-release
 
-      # must install specific dependencies before a build
-      # can't call npm install. doing so may fallback-to-build if package has yet to be published (double build)
+      # must install dependencies before using node-pre-gyp
+      # rather not call npm install as doing so may fallback-to-build if package has yet to be published.
       # use npm workaround specifying a package name to bypass install script in package.json
       - name: NPM Install dependencies
         run: npm install linux-os-info --unsafe-perm

--- a/.github/workflows/docker-node.yml
+++ b/.github/workflows/docker-node.yml
@@ -8,29 +8,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  load-docker-node:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+      # comments for: docker-node.json
+    - name: Load build group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/docker-node.json
+
   build-push:
     name: Build docker images
     runs-on: ubuntu-latest
+    needs: load-docker-node
+
     strategy:
       fail-fast: false
-      matrix: 
-        tag: [
-          '10-alpine3.9-build',
-          '10-centos7-build',
-          '10-amazonlinux2',
-          '10-centos7',
-          '10-centos8',
-          '12-alpine3.9-build',
-          '12-centos7-build',
-          '12-amazonlinux2',
-          '12-centos7',
-          '12-centos8',
-          '14-alpine3.10-build',
-          '14-centos7-build',
-          '14-amazonlinux2',
-          '14-centos7',
-          '14-centos8'
-        ]
+      matrix: ${{fromJson(needs.load-docker-node.outputs.matrix)}}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,21 +6,26 @@ on:
   workflow_dispatch:
 
 jobs:
+  load-build-group:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+      # build with the lowest versions of the OSs supported.
+      # ensures the glibc/musl versions are the oldest/most compatible.
+    - name: Load build group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
+
   build-group-test:
     runs-on: ubuntu-latest 
+    needs: load-build-group
     strategy:
       fail-fast: false
-      # build with the lowest versions of the OSs supported.
-      # ensures the glibc/musl versions are the oldest/most compatible. 
-      matrix: 
-        image: [
-          'ghcr.io/${{ github.repository }}/node:10-alpine3.9-build',
-          'ghcr.io/${{ github.repository }}/node:12-alpine3.9-build',
-          'ghcr.io/${{ github.repository }}/node:14-alpine3.10-build',
-          'ghcr.io/${{ github.repository }}/node:10-centos7-build',
-          'ghcr.io/${{ github.repository }}/node:12-centos7-build',
-          'ghcr.io/${{ github.repository }}/node:14-centos7-build'
-        ]
+      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
     container:
         image: ${{ matrix.image }}
 


### PR DESCRIPTION
This Pull Request is the **6th** in a series of Pull Requests to refactor GitHub Actions (AO-20081). 

It introduces **the main workflow** of this refactor - Accept which runs when a pull request is merged.

Overview:

The npm package in this repo is `node-pre-gyp` enabled and is published using in a two step process. First prebuilt add-on tarballs are uploaded to an S3 bucket, and then an NPM package is published to the NPM registry. Prebuilt tarballs must be versioned with the same version as the NPM package and they must be present in the S3 bucket prior to the NPM package itself being published to the registry. There are many platforms that can use the prebuilt add-on but will fail to build it, hence the importance of the prebuilts.

Definitions:

* Build Group are images on which the various versions of the add-on are built. They include combinations to support different Node versions and libc implementations. Generally build is done with the lowest versions of the OS supported, so that `glibc`/`musl` versions are the oldest/most compatible.
* Fallback Group images include OS and Node version combinations that *can* build for source.
* Prebuilt Group images include OS and Node version combinations that *can not* build for source and thus require a prebuilt tarball.

Usage:

* Merging a pull request will trigger accept.yml. 
* Workflow will:
  - Clear the *staging* S3* bucket of prebuilt tarballs (if exist for version).
  - Create all Fallback Group images and install. Since prebuilt tarball has been cleared, install will fallback to build from source.
  - Build the code pushed on each of the Build Group images.
  - Package the built code and upload a tarball to the *staging* S3 bucket. 
  - Create all Prebuilt Group images and install the prebuilt tarball on each.
* Workflow ensures node-pre-gyp setup (config and S3 buckets) is working for a wide variety of potential customer configurations.
* Manual trigger supported. Enables to select running the tests after install (on both Fallback & Prebuilt groups)


Diagram:

```
merge to master ─► ┌──────────────────────┐
                   │Fallback Group Install│
manual (test?) ──► └┬─────────────────────┘
                    │
                    │   ┌───────────────────────────┐ ─► ─► ─►
                    └─► │Build Group Build & Package│ S3 Package
                        └┬──────────────────────────┘ Staging
                         │
                         │   ┌──────────────────────┐     │
                         └─► │Prebuilt Group Install│ ◄── ▼
                             └──────────────────────┘
```

Todos:
  1. Move to tests to work against staging collector when AO-20147 is implemented.

Notes:
  * `matrix` and `container` directives are used. 
  * Jobs are chained using `needs` directive.
  * Configuration has been externalized. All images groups are loaded from external json files located in the `config` directory.
  * Loading uses [fromJSON function and a standard two-job setup](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#fromjson).
  * Loading is encapsulated in s shell script (`matrix-from-json.sh`). Since the script is not a "formal" action it is placed in a `script` directory.
  * Flow has been modified from [prototype](https://github.com/appoptics/appoptics-bindings-node/pull/45) so as to make it run in a deterministic manner regardless of version status.