### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-7

### DIFF
--- a/.github/config/target-group.json
+++ b/.github/config/target-group.json
@@ -1,0 +1,103 @@
+{
+  "include": [
+    {
+      "image": "node:10-buster"
+    },
+    {
+      "image": "node:10-buster-slim"
+    },
+    {
+      "image": "node:10-stretch"
+    },
+    {
+      "image": "node:10-stretch-slim"
+    },
+    {
+      "image": "node:10-alpine3.9"
+    },
+    {
+      "image": "node:10-alpine3.10"
+    },
+    {
+      "image": "node:10-alpine3.11"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-amazonlinux2"
+    },
+    {
+      "image": "node:12-buster"
+    },
+    {
+      "image": "node:12-buster-slim"
+    },
+    {
+      "image": "node:12-stretch"
+    },
+    {
+      "image": "node:12-stretch-slim"
+    },
+    {
+      "image": "node:12-alpine3.9"
+    },
+    {
+      "image": "node:12-alpine3.10"
+    },
+    {
+      "image": "node:12-alpine3.11"
+    },
+    {
+      "image": "node:12-alpine3.12"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-amazonlinux2"
+    },
+    {
+      "image": "node:14-buster"
+    },
+    {
+      "image": "node:14-buster-slim"
+    },
+    {
+      "image": "node:14-stretch"
+    },
+    {
+      "image": "node:14-stretch-slim"
+    },
+    {
+      "image": "node:14-alpine3.10"
+    },
+    {
+      "image": "node:14-alpine3.11"
+    },
+    {
+      "image": "node:14-alpine3.12"
+    },
+    {
+      "image": "node:14-alpine3.13"
+    },
+    {
+      "image": "node:14-alpine3.14"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-amazonlinux2"
+    }
+  ]
+}

--- a/.github/workflows/docker-node.yml
+++ b/.github/workflows/docker-node.yml
@@ -1,9 +1,14 @@
 name: Build Docker Images
 
 on:
-  push:
-    paths:
-      - '.github/docker-node/*.Dockerfile'
+  # TODO: revisit.
+  # as of July 2021, there seems to be a GitHub Actions bug causing this workflow to run when a tag is pushed.
+  # adding tags-ignore: causes the workflow to not run at all.
+  # since tag push is used for release trigger, decision was made to build images using manual trigger only.
+
+  # push:
+  #   paths:
+  #     - '.github/docker-node/*.Dockerfile'
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release! Build & Package, Target Prod Install, NPM Publish (Tag)
+
+on: 
+  push: 
+    tags: 
+      # triggered only by major/minor/patch tags and those specifically tagged alpha. 
+      # standard prerelease tags do not trigger.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-alpha.*'
+
+  # TODO: implement dry-run ?
+  # workflow_dispatch:
+
+jobs:
+  load-build-group:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+      # build with the lowest versions of the OSes supported so the glibc/musl versions # are the oldest/most compatible. 
+      # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
+    - name: Load build group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
+
+  build-group-publish:
+    runs-on: ubuntu-latest 
+    needs: load-build-group
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+    container:
+        image:  ${{ matrix.image }}
+
+    env: 
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      # must install specific dependencies before a build
+      # can't call npm install. doing so may fallback-to-build if package has yet to be published (double build)
+      # use npm workaround specifying a package name to bypass install script in package.json
+      - name: NPM Install dependencies
+        run: npm install linux-os-info --unsafe-perm
+
+      # must setup libobo before build
+      # node-pre-gyp rebuild runs "clean" and "build" at once.
+      # it is mapped to `node-gyp rebuild` which internally means "clean + configure + build" and triggers a full recompile
+      - name: Build
+        run: |
+          node setup-liboboe.js
+          npx node-pre-gyp rebuild
+
+      # artifacts are at:build/stage/nodejs/bindings/
+      - name: Package
+        run: npx node-pre-gyp package # requires clean rebuild
+
+      # *** IMPORTANT: 
+      # always include --s3_host flag regardless of node-pre-gyp defaults.
+      # workflows designed to ensure that the  staging bucket already has similarly versioned package
+      - name: Publish Package to Production
+        run: npx node-pre-gyp publish --s3_host=production
+
+  load-target-group:
+    runs-on: ubuntu-latest
+    needs: build-group-publish
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - name: Checkout ${{ github.ref }}
+      uses: actions/checkout@v2
+
+    - name: Load target group data
+      id: set-matrix
+      run: .github/scripts/matrix-from-json.sh .github/config/target-group.json
+
+  target-group-install:
+    runs-on: ubuntu-latest 
+    needs: load-target-group
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.load-target-group.outputs.matrix)}}
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+
+      - name: NPM Install Production
+        run: npm install --unsafe-perm --s3_host=production
+
+      - name: Check Artifacts
+        run: ls ./dist/napi-v*/apm_bindings.node && ls ./dist/napi-v*/ao_metrics.node
+
+  npm-publish:
+    runs-on: ubuntu-latest 
+    if: ${{ startsWith(github.ref, 'refs/tags/') }} # will not run when manually triggered
+    needs: target-group-install
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version 
+          cat /etc/os-release
+  
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'  # Setup .npmrc file to publish to npm
+
+      # *** IMPORTANT: 
+      # by default any package published to npm registry is tagged with 'latest'. to set other pass --tag. 
+      # any pre-release package (has - in version), regardless of name defined with version preid, will be npm tagged with 'prerelease'.
+      # package is scoped to organization (@appoptics/apm-binding) set --access public to avoid 402 Payment Required
+      - name: NPM Publish (alpha)
+        run: npm publish --tag prerelease --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        if: ${{ contains(github.ref, '-') }}
+
+      - name: NPM Publish (latest)
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        if: ${{ !contains(github.ref, '-') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-alpha.*'
 
-  # TODO: implement dry-run ?
-  # workflow_dispatch:
-
 jobs:
   load-build-group:
     runs-on: ubuntu-latest
@@ -113,7 +110,10 @@ jobs:
 
   npm-publish:
     runs-on: ubuntu-latest 
-    if: ${{ startsWith(github.ref, 'refs/tags/') }} # will not run when manually triggered
+    # stopgap. we should not get unless there is a tag ref.
+    # but there are several triggering issues open for GithHub runner.
+    # so recheck.
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: target-group-install
 
     steps:


### PR DESCRIPTION
This Pull Request is the **7th** in a series of Pull Requests to refactor GitHub Actions (AO-20081). 

It adds a release workflow that is `npm` and `git` triggered, using npm builtin `version` command and `git push tag`. No github hooks needed.

Definitions:
* Build Group are images on which the various versions of the add-on are built. They include combinations to support different Node versions and libc implementations. Generally build is done with the lowest versions of the OS supported, so that `glibc`/`musl` versions are the oldest/most compatible.
* Target Group images include a wide variety of OS and Node version combinations. Group includes both images that can build from code as well as those which can not.

Usage:
* To Release:
  1. On branch run `npm version {major/minor/patch}`(e.g. `npm version patch`) then have the branch pass through the Push/Pull/Merge flow above. 
  2. When ready `git push` origin {tag name} (e.g. `git push origin v11.2.3`).
* Pushing a semantic versioning tag for a patch/minor/major versions (e.g. `v11.2.3`) or an alpha tagged pre-release (e.g. `v11.2.3-alpha.2`) will trigger release.yml. Pushing other pre-release tags (e.g. `v11.2.3-7`) is ignored.

* Workflow will: 
  - Build the code pushed in each of the Build Group images. 
  - Package the built code and upload a tarball to the *production* S3 buckets. 
  - Create all Target Group images and install the prebuilt tarball on each.
  - Publish an NPM package upon successful completion of all steps above. When version tag is `alpha`, package will be NPM tagged same. When it is a release version, package will be NPM tagged `latest`.
* Workflow ensures node-pre-gyp setup is working in *production* for a wide variety of potential customer configurations.
* Workflow publishing to NPM registry exposes the NPM package (and the prebuilt tarballs in the *production* S3 bucket) to the public.
* Note: @appoptics/apm-bindings is not meant to be directly consumed. It is developed as a dependency of [appoptics-apm](https://www.npmjs.com/package/appoptics-apm).

Diagram:

```
push semver tag ─► ┌────────────────────────────┐ ─► ─► ─►
push alpha tag     │Build Group Build & Package │ S3 Package
                   └┬───────────────────────────┘ Production
                    │
                    │   ┌────────────────────┐     │
                    └─► │Target Group Install│ ◄── ▼
                        └┬───────────────────┘
                         │
                         │   ┌───────────┐
                         └─► │NPM Publish│
                             └───────────┘
```

Todos:
  1. Consider adding a dry-run option - will require deleting tarballs from production and running NPM publish with --dry-run. Benefits? Maybe...

Notes:
  * Publish is done from a runner with node 14.x installed. Choice of os/node version has *no* impact (at last ;) )
  * actions/setup-node@v2 handles `.npmrc` file creation for authentication. NPM_AUTH_TOKEN is never written to file.

GitHub Actions bugs:

Pushing a tag triggers not only the Release workflow but also the Build Docker Images workflow even though that one should only be triggered with:
```
on:
  push:
    paths:
      - '.github/docker-node/*.Dockerfile'
```
Adding `tags-ignore:` to the above in attempt to "circumvent" the bug will disable trigger all together. 
Will investigate further (and/or open issue with https://github.com/actions/runner/). 

**Decision was made to disable the trigger on the  Build Docker Images workflow. Images will be built by manual trigger.** (62f51ead1407568ffe385017de621a6c69fe6693)