### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-8

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -1,4 +1,4 @@
-name: Fallback Install, Build & Package & Prebuilt Install (Merge)
+name: Accept - Fallback Install, Build & Package & Prebuilt Install (on merge)
 
 on: 
   push: 
@@ -34,7 +34,7 @@ jobs:
     needs: load-build-group
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-build-group.outputs.matrix) }}
     container:
         image:  ${{ matrix.image }}
 
@@ -81,7 +81,7 @@ jobs:
     needs: load-fallback-group
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-fallback-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-fallback-group.outputs.matrix) }}
     container:
         image: ${{ matrix.image }}
 
@@ -117,7 +117,7 @@ jobs:
     needs: [load-build-group, fallback-group-install]
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-build-group.outputs.matrix) }}
     container:
         image:  ${{ matrix.image }}
 
@@ -179,7 +179,7 @@ jobs:
     needs: load-prebuilt-group
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-prebuilt-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-prebuilt-group.outputs.matrix) }}
     container:
         image: ${{ matrix.image }}
 

--- a/.github/workflows/docker-node.yml
+++ b/.github/workflows/docker-node.yml
@@ -1,4 +1,4 @@
-name: Build Docker Images
+name: Prep - Build Docker Images (manual)
 
 on:
   # TODO: revisit.
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-docker-node.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-docker-node.outputs.matrix) }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,4 +1,4 @@
-name: Single Build & Test (Push)
+name: Push - Single Build & Test (on push)
 
 # workflow is for a branch push only and ignores master.
 # push to master (which is also pull request merge) has a more elaborate workflow to run

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches-ignore:
       - 'master'
+      # any branch with a name ending in -no-build will not trigger this workflow.
+      - '*-no-build'
 
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release! Build & Package, Target Prod Install, NPM Publish (Tag)
+name: Release - Build & Package, Target Prod Install, NPM Publish (on push tag)
 
 on: 
   push: 
@@ -28,7 +28,7 @@ jobs:
     needs: load-build-group
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-build-group.outputs.matrix) }}
     container:
         image:  ${{ matrix.image }}
 
@@ -89,7 +89,7 @@ jobs:
     needs: load-target-group
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-target-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-target-group.outputs.matrix) }}
 
     steps:
       - name: Checkout ${{ github.ref }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,4 +1,4 @@
-name: Group Build & Test (Pull)
+name: Review - Group Build & Test (on pull)
 
 on: 
   pull_request: 
@@ -25,7 +25,7 @@ jobs:
     needs: load-build-group
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.load-build-group.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.load-build-group.outputs.matrix) }}
     container:
         image: ${{ matrix.image }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appoptics/apm-bindings",
-  "version": "11.0.0",
+  "version": "11.0.1-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "!darwin",
     "!win32"
   ],
-  "version": "11.0.0",
+  "version": "11.0.1-alpha.0",
   "appoptics": {
     "version-suffix": "lambda-1"
   },

--- a/test/expose-gc/init-memory.test.js
+++ b/test/expose-gc/init-memory.test.js
@@ -39,9 +39,7 @@ const goodOptions = {
 
 describe('init-memory', function (done) {
   it('should oboeInit without losing memory', function (done) {
-    // node 8, 10 completes in < 30 seconds but node 12 takes longer
-    // node 14 with docker needs about 90 seconds
-    this.timeout(process.env.CI ? 100000 : 90000);
+    this.timeout(120000);
     const warmup = 1000000;
     const checkCount = 1000000;
     const tolerance = process.env.CI ? checkCount * 2 : checkCount;


### PR DESCRIPTION
This Pull Request is the **8th** and **last** in a series of Pull Requests to refactor GitHub Actions (AO-20081). 

Wrapping things up by increasing timeout on flaky test (35f511e6e1394d600ab79ad366f60d1514552409), renaming the workflows to better display in GitHub Actions sidebar (698dab1e2ae2b4a30dd2b146ca3eae2625b0facc) and adding a way to designate a branch so that it would not trigger a build on push (698dab1e2ae2b4a30dd2b146ca3eae2625b0facc). Main use case for latter is GitHub online documentation editor commits. No other filtering scheme works as planned.

Onwards.

P.S - Multiple feature branches, draft PRs,  rebasing, pushing with --force-with-lease. Github seems very excited logging things below... ignore...