### PR TITLE
AO-20084-Enable-Support-for-Node-16

### DIFF
--- a/.github/config/build-group.json
+++ b/.github/config/build-group.json
@@ -5,22 +5,22 @@
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-alpine3.9-build"
     },
     {
-      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-alpine3.9-build"
-    },
-    {
-      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-alpine3.10-build"
-    },
-    {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:10-centos7-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-alpine3.9-build"
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:12-centos7-build"
     },
     {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-alpine3.9-build"
+    },
+    {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos7-build"
     },
     {
-      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.11-build"
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.9-build"
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos7-build"

--- a/.github/config/build-group.json
+++ b/.github/config/build-group.json
@@ -18,6 +18,12 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-centos7-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.11-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos7-build"
     }
   ]
 }

--- a/.github/config/docker-node.json
+++ b/.github/config/docker-node.json
@@ -31,10 +31,13 @@
       "tag": "12-centos8",
     },
     {
-      "tag": "14-alpine3.10-build",
+      "tag": "14-alpine3.9-build",
     },
     {
       "tag": "14-centos7-build",
+    },
+    {
+      "tag": "14-alpine3.9",
     },
     {
       "tag": "14-amazonlinux2",
@@ -46,10 +49,16 @@
       "tag": "14-centos8",
     },
     {
-      "tag": "16-alpine3.11-build",
+      "tag": "16-alpine3.9-build",
     },
     {
       "tag": "16-centos7-build",
+    },
+    {
+      "tag": "16-alpine3.9",
+    },
+    {
+      "tag": "16-alpine3.10",
     },
     {
       "tag": "16-amazonlinux2",

--- a/.github/config/docker-node.json
+++ b/.github/config/docker-node.json
@@ -44,6 +44,21 @@
     },
     {
       "tag": "14-centos8",
+    },
+    {
+      "tag": "16-alpine3.11-build",
+    },
+    {
+      "tag": "16-centos7-build",
+    },
+    {
+      "tag": "16-amazonlinux2",
+    },
+    {
+      "tag": "16-centos7",
+    },
+    {
+      "tag": "16-centos8",
     }
   ]
 }

--- a/.github/config/fallback-group.json
+++ b/.github/config/fallback-group.json
@@ -17,6 +17,12 @@
     },
     {
       "image": "node:14-stretch"
+    },
+    {
+      "image": "node:16-buster"
+    },
+    {
+      "image": "node:16-stretch"
     }
   ]
 }

--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -58,6 +58,9 @@
       "image": "node:14-stretch-slim"
     },
     {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-alpine3.9"
+    },
+    {
       "image": "node:14-alpine3.10"
     },
     {
@@ -86,6 +89,12 @@
     },
     {
       "image": "node:16-stretch-slim"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.9"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.10"
     },
     {
       "image": "node:16-alpine3.11"

--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -80,6 +80,33 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-amazonlinux2"
+    },
+    {
+      "image": "node:16-buster-slim"
+    },
+    {
+      "image": "node:16-stretch-slim"
+    },
+    {
+      "image": "node:16-alpine3.11"
+    },
+    {
+      "image": "node:16-alpine3.12"
+    },
+    {
+      "image": "node:16-alpine3.13"
+    },
+    {
+      "image": "node:16-alpine3.14"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-amazonlinux2"
     }
   ]
 }

--- a/.github/config/target-group.json
+++ b/.github/config/target-group.json
@@ -76,6 +76,9 @@
       "image": "node:14-stretch-slim"
     },
     {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-alpine3.9"
+    },
+    {
       "image": "node:14-alpine3.10"
     },
     {
@@ -110,6 +113,12 @@
     },
     {
       "image": "node:16-stretch-slim"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.9"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-alpine3.10"
     },
     {
       "image": "node:16-alpine3.11"

--- a/.github/config/target-group.json
+++ b/.github/config/target-group.json
@@ -98,6 +98,39 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-amazonlinux2"
+    },
+    {
+      "image": "node:16-buster"
+    },
+    {
+      "image": "node:16-buster-slim"
+    },
+    {
+      "image": "node:16-stretch"
+    },
+    {
+      "image": "node:16-stretch-slim"
+    },
+    {
+      "image": "node:16-alpine3.11"
+    },
+    {
+      "image": "node:16-alpine3.12"
+    },
+    {
+      "image": "node:16-alpine3.13"
+    },
+    {
+      "image": "node:16-alpine3.14"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-amazonlinux2"
     }
   ]
 }

--- a/.github/docker-node/14-alpine3.10-build.Dockerfile
+++ b/.github/docker-node/14-alpine3.10-build.Dockerfile
@@ -1,7 +1,0 @@
-FROM node:14-alpine3.10
-
-# install software required for this OS
-RUN apk update && apk add \
-  g++ \
-  python2 \
-  make

--- a/.github/docker-node/14-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/14-alpine3.9-build.Dockerfile
@@ -1,0 +1,107 @@
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/fd130acf063b312355a5d88d51716db3ff34ae49/14/alpine3.11/Dockerfile
+# Only modification FROM alpine:3.9
+FROM alpine:3.9
+
+ENV NODE_VERSION 14.17.3
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="58d33d68cf72b41044ea40cfb8ac39c64e3e537b8475426f33b5b54d5712c2b8" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.5
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]
+
+
+# install software required for this OS
+RUN apk update && apk add \
+  g++ \
+  python2 \
+  make

--- a/.github/docker-node/14-alpine3.9.Dockerfile
+++ b/.github/docker-node/14-alpine3.9.Dockerfile
@@ -1,0 +1,100 @@
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/fd130acf063b312355a5d88d51716db3ff34ae49/14/alpine3.11/Dockerfile
+# Only modification FROM alpine:3.9
+FROM alpine:3.9
+
+ENV NODE_VERSION 14.17.3
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="58d33d68cf72b41044ea40cfb8ac39c64e3e537b8475426f33b5b54d5712c2b8" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.5
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]

--- a/.github/docker-node/16-alpine3.10.Dockerfile
+++ b/.github/docker-node/16-alpine3.10.Dockerfile
@@ -1,0 +1,100 @@
+# Taken from https://github.com/nodejs/docker-node/blob/ce3bb541693325ee21e38184873ceb4364b3e6f4/16/alpine3.11/Dockerfile
+# Only modification FROM alpine:3.10
+FROM alpine:3.10
+
+ENV NODE_VERSION 16.5.0
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="64c1063a622e9620209b6081310036c7b48a4ee9a342dfbb9d015f1781f1444e" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.5
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]

--- a/.github/docker-node/16-alpine3.11-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.11-build.Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16-alpine3.11
+
+# install software required for this OS
+RUN apk update && apk add \
+  g++ \
+  python2 \
+  make

--- a/.github/docker-node/16-alpine3.11-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.11-build.Dockerfile
@@ -1,7 +1,0 @@
-FROM node:16-alpine3.11
-
-# install software required for this OS
-RUN apk update && apk add \
-  g++ \
-  python2 \
-  make

--- a/.github/docker-node/16-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.9-build.Dockerfile
@@ -1,0 +1,107 @@
+# Taken from https://github.com/nodejs/docker-node/blob/ce3bb541693325ee21e38184873ceb4364b3e6f4/16/alpine3.11/Dockerfile
+# Only modification FROM alpine:3.9
+FROM alpine:3.9
+
+ENV NODE_VERSION 16.5.0
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="64c1063a622e9620209b6081310036c7b48a4ee9a342dfbb9d015f1781f1444e" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.5
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]
+
+# install software required for this OS
+RUN apk update && apk add \
+  g++ \
+  python2 \
+  make
+

--- a/.github/docker-node/16-alpine3.9.Dockerfile
+++ b/.github/docker-node/16-alpine3.9.Dockerfile
@@ -1,0 +1,100 @@
+# Taken from https://github.com/nodejs/docker-node/blob/ce3bb541693325ee21e38184873ceb4364b3e6f4/16/alpine3.11/Dockerfile
+# Only modification FROM alpine:3.9
+FROM alpine:3.9
+
+ENV NODE_VERSION 16.5.0
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="64c1063a622e9620209b6081310036c7b48a4ee9a342dfbb9d015f1781f1444e" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.5
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -1,0 +1,29 @@
+FROM amazonlinux:2
+
+ENV NODE_VERSION 16.3.0
+
+# install software required for this OS
+RUN yum -y install \
+    tar \
+    gzip
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 16.3.0
+ENV NODE_VERSION 16.5.0
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -9,11 +9,12 @@ RUN yum -y install \
 
 # yum install gcc-c++  will install version 4.8.5
 # we need a higher version that supports c++ 14.
-# following will get version 7.3.1 and set as default
+# see: https://github.com/nodejs/node/blob/master/BUILDING.md#supported-toolchains
+# following will get version 8.3.1 and set as default
 RUN yum install -y centos-release-scl
-RUN yum install -y devtoolset-7-gcc*
+RUN yum install -y devtoolset-8-gcc*
 
-ENV PATH=/opt/rh/devtoolset-7/root/bin:$PATH
+ENV PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.3.0
+ENV NODE_VERSION 16.5.0
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:7
+
+ENV NODE_VERSION 16.3.0
+
+# install software required for this OS
+RUN yum -y install \
+  python2 \
+  make
+
+# yum install gcc-c++  will install version 4.8.5
+# we need a higher version that supports c++ 14.
+# following will get version 7.3.1 and set as default
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-7-gcc*
+
+ENV PATH=/opt/rh/devtoolset-7/root/bin:$PATH
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/16-centos7.Dockerfile
+++ b/.github/docker-node/16-centos7.Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:7
+
+ENV NODE_VERSION 16.3.0
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/.github/docker-node/16-centos7.Dockerfile
+++ b/.github/docker-node/16-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.3.0
+ENV NODE_VERSION 16.5.0
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos8.Dockerfile
+++ b/.github/docker-node/16-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 16.3.0
+ENV NODE_VERSION 16.5.0
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos8.Dockerfile
+++ b/.github/docker-node/16-centos8.Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:8
+
+ENV NODE_VERSION 16.3.0
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/.github/docker-node/docker-entrypoint.sh
+++ b/.github/docker-node/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  set -- node "$@"
+fi
+
+exec "$@"

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -43,6 +43,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
 
     steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
@@ -90,6 +94,10 @@ jobs:
       AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
 
     steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
@@ -126,6 +134,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
 
     steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
@@ -188,6 +200,10 @@ jobs:
       AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
 
     steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
@@ -209,3 +225,12 @@ jobs:
       - name: Run tests
         run: npm test
         if: ${{ github.event.inputs.target-test }}
+
+      # Why Change Owner of Container Working Directory?
+
+      # the working directory is created by the runner and mounted to the container.
+      # container user is root and the runner is not a user in the container.
+      # this is a github actions design flaw.
+      # when npm 7 is run as root, scripts are always run with the effective uid and gid of the working directory owner.
+      # node 16 can't install under default setup.
+      # specifying workdir for container and path for checkout does not work due to bug.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
 
     steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
@@ -92,6 +96,10 @@ jobs:
       matrix: ${{ fromJson(needs.load-target-group.outputs.matrix) }}
 
     steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
@@ -148,3 +156,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
         if: ${{ !contains(github.ref, '-') }}
+
+      # Why Change Owner of Container Working Directory?
+
+      # the working directory is created by the runner and mounted to the container.
+      # container user is root and the runner is not a user in the container.
+      # this is a github actions design flaw.
+      # when npm 7 is run as root, scripts are always run with the effective uid and gid of the working directory owner.
+      # node 16 can't install under default setup.
+      # specifying workdir for container and path for checkout does not work due to bug.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,6 +34,15 @@ jobs:
       AO_TOKEN_PROD: ${{ secrets.AO_TOKEN_PROD }}
 
     steps:
+      # the working directory is created by the runner and mounted to the container.
+      # container user is root and the runner is not a user in the container.
+      # this is a github actions design flaw.
+      # when npm 7 is run as root, scripts are always run with the effective uid and gid of the working directory owner.
+      # node 16 can't install under default setup.
+      # specifying workdir for container and path for checkout does not work due to bug.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 


### PR DESCRIPTION
This Pull Request adds support for Node 16 by:
1. Adding the Dockerfiles (be4c3a6e197dbb958bf83b8edfa74644df3c93f3) (image build has been triggered manually)
2. Adding resulting images to config groups (96198d90904530205baf2e5697cdb31fdb703360)
3. Modifying matrix/container workflows to allow npm install (cea153172649e6100919dfa670cc85c9911041b9).

Support for Node 16 required two adjustments over previous versions:

1. Node moved to [c++14](https://github.com/nodejs/node/commit/f9d6de41a7cb7e512eab4e8ed9b9a5dbfbac11e2#diff-9513a0c08584f4800e1461ca8c3456d1aeb899968ea14b2f6859ea462c37b5bb) which does not compile on Centos 7 "out of the box" (but does on Centos 8).
  
    Centos 7 comes with:
    - gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
    - glibc-2.17-324.el7_9.x86_64
   
    Centos 8 comes with:
    - gcc (GCC) 8.4.1 20200928 (Red Hat 8.4.1-1)
    - glibc-2.28-151.el8.x86_64
    
    Since we want to build with the lowest versions of the OSs supported to ensures the glibc/musl versions are the oldest/most compatible, the [build image](https://github.com/appoptics/appoptics-bindings-node/blob/be4c3a6e197dbb958bf83b8edfa74644df3c93f3/.github/docker-node/16-centos7-build.Dockerfile) is using Centos 7 with an upgraded gcc (version 7.3.1).


2. NPM introduced [breaking changes to lifecycle scripts](https://github.com/npm/cli/blob/e1a2837809a76896523cdfcbce7537e46f71d67e/CHANGELOG.md#v700-beta0-2020-08-04) which rendered the `--unsafe-perm` flag obsolete. 

    Moving Forward *"The user, group, uid, gid, and unsafe-perms configurations are no longer relevant. When npm is run as root, scripts are always run with the effective uid and gid of the working directory owner"*.

     This behavior required adjustments in order to run successfully on the GitHub platform.  GitHub Actions issue opened: https://github.com/actions/runner/issues/1203. It may present some (unavoidable) challenges to downstream customers in the future.
