### PR TITLE
AO-20163-Remove-Outdated-Support-Email-Address

### DIFF
--- a/setup-liboboe.js
+++ b/setup-liboboe.js
@@ -17,8 +17,7 @@ const deleteUnused = false
 //
 const oboeNames = {
   linux: 'liboboe-1.0-x86_64.so.0.0.0',
-  alpine: 'liboboe-1.0-alpine-x86_64.so.0.0.0',
-  alpineLibreSSL: 'liboboe-1.0-alpine-libressl-x86_64.so.0.0.0'
+  alpine: 'liboboe-1.0-alpine-x86_64.so.0.0.0'
 }
 
 function setupLiboboe (cb) {

--- a/setup-liboboe.js
+++ b/setup-liboboe.js
@@ -22,8 +22,6 @@ const oboeNames = {
 }
 
 function setupLiboboe (cb) {
-  // const version = fs.readFileSync(dir + 'VERSION', 'utf8').slice(0, -1)
-
   releaseInfo().then(info => {
     if (info.platform !== 'linux') {
       /* eslint-disable no-console */
@@ -36,14 +34,6 @@ function setupLiboboe (cb) {
     let versionKey = 'linux'
     if (info.id === 'alpine') {
       versionKey = 'alpine'
-      // if greater than version 3.9 then use alpine with openSSL. if less than 3.9
-      // use the libreSSL version.
-      // const parts = info.version_id.split('.').map(p => parseInt(p));
-      // if (parts[0] > 3) {
-      //  versionKey = 'alpine';
-      // } else {
-      //  versionKey = parts[0] === 3 && parts[1] >= 9 ? 'alpine' : 'alpineLibreSSL';
-      // }
     }
     return versionKey
   }).then(linux => {

--- a/setup-liboboe.js
+++ b/setup-liboboe.js
@@ -26,18 +26,12 @@ function setupLiboboe (cb) {
 
   releaseInfo().then(info => {
     if (info.platform !== 'linux') {
-      const line1 = `AppopticsApm warning: the ${info.platform} platform is not yet supported`
-      const line2 = 'see: https://docs.appoptics.com/kb/apm_tracing/supported_platforms/'
-      const line3 = 'Contact support@appoptics.com if this is unexpected.'
-      const bar = '='.repeat([line1, line2, line3].reduce((m, l) => l.length > m ? l.length : m, 0))
       /* eslint-disable no-console */
-      console.log(bar)
-      console.log(line1)
-      console.log(line2)
-      console.log(line3)
-      console.log(bar)
-      process.exit(1)
+      console.log(`AppopticsApm warning: the ${info.platform} platform is not yet supported`)
+      console.log('see: https://docs.appoptics.com/kb/apm_tracing/supported_platforms/')
+      console.log(' ')
       /* eslint-enable no-console */
+      process.exit(1)
     }
     let versionKey = 'linux'
     if (info.id === 'alpine') {


### PR DESCRIPTION
This Pull Request modifies `setup-liboboe.js`.

It:
- Removes outdated email address and some decoration from liboboe's platform warning message (2754a9f)
- Removes commented-out code (2170016)
- Removes dead-code reference to alpineLibreSSL (9ce36b2)

Build check/tests pass.

Note that `package.josn` has an `os` setting:
```
  "os": [
    "!darwin",
    "!win32"
  ],
```
And will in most cases (all?) halt install/rebuild before setup-liboboe.js is invoked