### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-9

### DIFF
--- a/.github/docker-node/12-amazonlinux2.Dockerfile
+++ b/.github/docker-node/12-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 12.22.1
+ENV NODE_VERSION 12.22.5
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/12-centos7-build.Dockerfile
+++ b/.github/docker-node/12-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 12.22.1
+ENV NODE_VERSION 12.22.5
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/12-centos7.Dockerfile
+++ b/.github/docker-node/12-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 12.22.1
+ENV NODE_VERSION 12.22.5
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/12-centos8.Dockerfile
+++ b/.github/docker-node/12-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 12.22.1
+ENV NODE_VERSION 12.22.5
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/14-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/14-alpine3.9-build.Dockerfile
@@ -1,5 +1,7 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/fd130acf063b312355a5d88d51716db3ff34ae49/14/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/a16a841095bcefefaf0ec43ba39f91fc788b03d4/14/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
+
+# begin copied content
 FROM alpine:3.9
 
 ENV NODE_VERSION 14.17.5
@@ -14,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="58d33d68cf72b41044ea40cfb8ac39c64e3e537b8475426f33b5b54d5712c2b8" \
+          CHECKSUM="8889a3ea0d0d8247132cf257ccd4828ddcd7e373f67c875878035b131e9fa1ac" \
           ;; \
         *) ;; \
       esac \
@@ -98,7 +100,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD [ "node" ]
-
+# end copied content
 
 # install software required for this OS
 RUN apk update && apk add \

--- a/.github/docker-node/14-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/14-alpine3.9-build.Dockerfile
@@ -2,7 +2,7 @@
 # Only modification FROM alpine:3.9
 FROM alpine:3.9
 
-ENV NODE_VERSION 14.17.3
+ENV NODE_VERSION 14.17.5
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/.github/docker-node/14-alpine3.9.Dockerfile
+++ b/.github/docker-node/14-alpine3.9.Dockerfile
@@ -1,5 +1,7 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/fd130acf063b312355a5d88d51716db3ff34ae49/14/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/a16a841095bcefefaf0ec43ba39f91fc788b03d4/14/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
+
+# begin copied content
 FROM alpine:3.9
 
 ENV NODE_VERSION 14.17.5
@@ -14,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="58d33d68cf72b41044ea40cfb8ac39c64e3e537b8475426f33b5b54d5712c2b8" \
+          CHECKSUM="8889a3ea0d0d8247132cf257ccd4828ddcd7e373f67c875878035b131e9fa1ac" \
           ;; \
         *) ;; \
       esac \
@@ -98,3 +100,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD [ "node" ]
+# end copied content

--- a/.github/docker-node/14-alpine3.9.Dockerfile
+++ b/.github/docker-node/14-alpine3.9.Dockerfile
@@ -2,7 +2,7 @@
 # Only modification FROM alpine:3.9
 FROM alpine:3.9
 
-ENV NODE_VERSION 14.17.3
+ENV NODE_VERSION 14.17.5
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/.github/docker-node/14-amazonlinux2.Dockerfile
+++ b/.github/docker-node/14-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 14.17.0
+ENV NODE_VERSION 14.17.5
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/14-centos7-build.Dockerfile
+++ b/.github/docker-node/14-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 14.17.0
+ENV NODE_VERSION 14.17.5
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/14-centos7.Dockerfile
+++ b/.github/docker-node/14-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 14.17.0
+ENV NODE_VERSION 14.17.5
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/14-centos8.Dockerfile
+++ b/.github/docker-node/14-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 14.17.0
+ENV NODE_VERSION 14.17.5
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-alpine3.10.Dockerfile
+++ b/.github/docker-node/16-alpine3.10.Dockerfile
@@ -2,7 +2,7 @@
 # Only modification FROM alpine:3.10
 FROM alpine:3.10
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/.github/docker-node/16-alpine3.10.Dockerfile
+++ b/.github/docker-node/16-alpine3.10.Dockerfile
@@ -1,8 +1,10 @@
-# Taken from https://github.com/nodejs/docker-node/blob/ce3bb541693325ee21e38184873ceb4364b3e6f4/16/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/f52a9c90a41f916c213bfb6bad904928e9fdd3b3/16/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.10
+
+# begin copied content
 FROM alpine:3.10
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -14,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="64c1063a622e9620209b6081310036c7b48a4ee9a342dfbb9d015f1781f1444e" \
+          CHECKSUM="9c8438a8d9a1e268153812d1d3f7f63b02283e2082dcd39274674f897496a22a" \
           ;; \
         *) ;; \
       esac \
@@ -98,3 +100,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD [ "node" ]
+# end copied content

--- a/.github/docker-node/16-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.9-build.Dockerfile
@@ -2,7 +2,7 @@
 # Only modification FROM alpine:3.9
 FROM alpine:3.9
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/.github/docker-node/16-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.9-build.Dockerfile
@@ -1,8 +1,10 @@
-# Taken from https://github.com/nodejs/docker-node/blob/ce3bb541693325ee21e38184873ceb4364b3e6f4/16/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/f52a9c90a41f916c213bfb6bad904928e9fdd3b3/16/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
+
+# begin copied content
 FROM alpine:3.9
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -14,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="64c1063a622e9620209b6081310036c7b48a4ee9a342dfbb9d015f1781f1444e" \
+          CHECKSUM="9c8438a8d9a1e268153812d1d3f7f63b02283e2082dcd39274674f897496a22a" \
           ;; \
         *) ;; \
       esac \
@@ -98,6 +100,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD [ "node" ]
+# end copied content
 
 # install software required for this OS
 RUN apk update && apk add \

--- a/.github/docker-node/16-alpine3.9.Dockerfile
+++ b/.github/docker-node/16-alpine3.9.Dockerfile
@@ -2,7 +2,7 @@
 # Only modification FROM alpine:3.9
 FROM alpine:3.9
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \

--- a/.github/docker-node/16-alpine3.9.Dockerfile
+++ b/.github/docker-node/16-alpine3.9.Dockerfile
@@ -1,8 +1,10 @@
-# Taken from https://github.com/nodejs/docker-node/blob/ce3bb541693325ee21e38184873ceb4364b3e6f4/16/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/f52a9c90a41f916c213bfb6bad904928e9fdd3b3/16/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
+
+# begin copied content
 FROM alpine:3.9
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -14,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="64c1063a622e9620209b6081310036c7b48a4ee9a342dfbb9d015f1781f1444e" \
+          CHECKSUM="9c8438a8d9a1e268153812d1d3f7f63b02283e2082dcd39274674f897496a22a" \
           ;; \
         *) ;; \
       esac \
@@ -98,3 +100,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 CMD [ "node" ]
+# end copied content

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7.Dockerfile
+++ b/.github/docker-node/16-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos7.Dockerfile
+++ b/.github/docker-node/16-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos8.Dockerfile
+++ b/.github/docker-node/16-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 16.5.0
+ENV NODE_VERSION 16.6.2
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos8.Dockerfile
+++ b/.github/docker-node/16-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 16.6.2
+ENV NODE_VERSION 16.6.1
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -16,20 +16,23 @@ on:
 jobs:
   # both build-group-unpublish and  build-group-publish "needs" this job
   load-build-group:
+    name: Load Build Group Config JSON
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
 
-      # build with the lowest versions of the OSes supported so the glibc/musl versions are the oldest/most compatible. 
-      # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
-    - name: Load build group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+        # build with the lowest versions of the OSes supported so the glibc/musl versions are the oldest/most compatible. 
+        # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
+      - name: Load build group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
 
   build-group-unpublish:
+    name: Build Group Unpublish
     runs-on: ubuntu-latest 
     needs: load-build-group
     strategy:
@@ -67,20 +70,23 @@ jobs:
         run: npx node-pre-gyp unpublish --s3_host=staging
 
   load-fallback-group:
+    name: Load Fallback Group Config JSON
     runs-on: ubuntu-latest
     needs: build-group-unpublish
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
 
-      # contains images that are able to build "out of the box"
-    - name: Load target group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/fallback-group.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+        # contains images that are able to build "out of the box"
+      - name: Load target group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/fallback-group.json
 
   fallback-group-install:
+    name: Fallback Group Install
     runs-on: ubuntu-latest
     needs: load-fallback-group
     strategy:
@@ -121,6 +127,7 @@ jobs:
         if: ${{ github.event.inputs.target-test }}
 
   build-group-publish:
+    name: Build Group Publish
     runs-on: ubuntu-latest 
     needs: [load-build-group, fallback-group-install]
     strategy:
@@ -173,20 +180,23 @@ jobs:
         run: npx node-pre-gyp publish --s3_host=staging
 
   load-prebuilt-group:
+    name: Load Prebuilt Group Config JSON
     runs-on: ubuntu-latest
     needs: build-group-publish
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
 
-      # contains images that are unable to build "out of the box" and will install prebuilt
-    - name: Load target group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/prebuilt-group.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+        # contains images that are unable to build "out of the box" and will install prebuilt
+      - name: Load target group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/prebuilt-group.json
 
   prebuilt-group-install:
+    name: Prebuilt Group Install
     runs-on: ubuntu-latest 
     needs: load-prebuilt-group
     strategy:

--- a/.github/workflows/docker-node.yml
+++ b/.github/workflows/docker-node.yml
@@ -1,33 +1,40 @@
-name: Prep - Build Docker Images (manual)
+name: Prep - Build Docker Image (on Dockerfile push)
 
+# workflow is for a branch push only and ignores master.
+# push to master (which is also pull request merge) has a more elaborate workflow to run
+# github repo is configured with branch protection on master.
 on:
-  # TODO: revisit.
-  # as of July 2021, there seems to be a GitHub Actions bug causing this workflow to run when a tag is pushed.
-  # adding tags-ignore: causes the workflow to not run at all.
-  # since tag push is used for release trigger, decision was made to build images using manual trigger only.
-
-  # push:
-  #   paths:
-  #     - '.github/docker-node/*.Dockerfile'
+  push:
+    branches-ignore:
+      - 'master'
+    paths:
+      - '.github/docker-node/*.Dockerfile'
 
   workflow_dispatch:
 
 jobs:
   load-docker-node:
+    name: Load Docker Node Config JSON
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
+    # github actions triggered by on push will be triggered by both branch and tag push.
+    # the paths filter only applies to branch push and as a result the workflow will run on tag push.
+    # adding tags-ignore: filter causes the workflow to not run at all.
+    # add a conditional to prevent tag push runs.
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-      # comments for: docker-node.json
-    - name: Load build group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/docker-node.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+        # comments for: docker-node.json
+      - name: Load build group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/docker-node.json
 
   build-push:
-    name: Build docker images
+    name: Build Docker Images
     runs-on: ubuntu-latest
     needs: load-docker-node
 
@@ -36,7 +43,7 @@ jobs:
       matrix: ${{ fromJson(needs.load-docker-node.outputs.matrix) }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
       - name: Log in to the Container registry

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,8 +7,8 @@ on:
   push:
     branches-ignore:
       - 'master'
-      # any branch with a name ending in -no-build will not trigger this workflow.
-      - '*-no-build'
+      # any branch with a name ending in -no-action will not trigger this workflow.
+      - '*-no-action'
 
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   build-single-test:
+    name: Build Single Test
     runs-on: ubuntu-latest # environment job will run in
 
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,20 +10,23 @@ on:
 
 jobs:
   load-build-group:
+    name: Load Build Group Config JSON
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
 
-      # build with the lowest versions of the OSes supported so the glibc/musl versions # are the oldest/most compatible. 
-      # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
-    - name: Load build group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+        # build with the lowest versions of the OSes supported so the glibc/musl versions # are the oldest/most compatible. 
+        # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
+      - name: Load build group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
 
   build-group-publish:
+    name: Build Group Publish
     runs-on: ubuntu-latest 
     needs: load-build-group
     strategy:
@@ -76,19 +79,22 @@ jobs:
         run: npx node-pre-gyp publish --s3_host=production
 
   load-target-group:
+    name: Load Target Group Config JSON
     runs-on: ubuntu-latest
     needs: build-group-publish
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
 
-    - name: Load target group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/target-group.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Load target group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/target-group.json
 
   target-group-install:
+    name: Target Group Install
     runs-on: ubuntu-latest 
     needs: load-target-group
     strategy:
@@ -117,6 +123,7 @@ jobs:
         run: ls ./dist/napi-v*/apm_bindings.node && ls ./dist/napi-v*/ao_metrics.node
 
   npm-publish:
+    name: NPM Publish
     runs-on: ubuntu-latest 
     # stopgap. we should not get unless there is a tag ref.
     # but there are several triggering issues open for GithHub runner.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,20 +7,23 @@ on:
 
 jobs:
   load-build-group:
+    name: Load Build Group Config JSON
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-    - name: Checkout ${{ github.ref }}
-      uses: actions/checkout@v2
 
-      # build with the lowest versions of the OSs supported.
-      # ensures the glibc/musl versions are the oldest/most compatible.
-    - name: Load build group data
-      id: set-matrix
-      run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+        # build with the lowest versions of the OSs supported.
+        # ensures the glibc/musl versions are the oldest/most compatible.
+      - name: Load build group data
+        id: set-matrix
+        run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
 
   build-group-test:
+    name: Build Group Test
     runs-on: ubuntu-latest 
     needs: load-build-group
     strategy:

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -35,8 +35,8 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | b
 # these are the stable versions as of July 2021
 # cant use lts alias due to all sorts of Dockerfile limitations.
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install v14.17.3 \
-    && nvm install v12.22.3 \
+    && nvm install v14.17.5 \
+    && nvm install v12.22.5 \
     && nvm install v10.24.1 \
     && nvm install stable
 
@@ -44,5 +44,5 @@ RUN source $NVM_DIR/nvm.sh \
 # stay with 14.
 
 # add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v14.17.3/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v14.17.3/bin:$PATH
+ENV NODE_PATH $NVM_DIR/v14.17.5/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v14.17.5/bin:$PATH

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.960.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.960.0.tgz",
-      "integrity": "sha512-e3KNZ5x0uzBNbVLbGUO2xrMRonUPpmXxgyZ/MaHx5yOQIv9G2a7dei/TvrMa9rl4MFCScGLw1LjbYb7CrdbMBQ==",
+      "version": "2.970.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.970.0.tgz",
+      "integrity": "sha512-9+ktvE5xgpHr3RsFOcq1SrhXLvU+jUji44jbecFZb5C2lzoEEB29aeN39OLJMW0ZuOrR+3TNum8c3f8YVx6A7w==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -792,36 +792,30 @@
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.13.1"
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         }
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
-      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
+      "integrity": "sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
@@ -850,17 +844,17 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.23.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
-      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
+      "integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.4",
-        "eslint-module-utils": "^2.6.1",
+        "eslint-import-resolver-node": "^0.3.5",
+        "eslint-module-utils": "^2.6.2",
         "find-up": "^2.0.0",
         "has": "^1.0.3",
         "is-core-module": "^2.4.0",
@@ -899,13 +893,13 @@
       }
     },
     "eslint-plugin-json": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.0.0.tgz",
-      "integrity": "sha512-7qoY5pbzBLEttJWy4/cDtULK3EKglgIwfXk5Yqp3StJaQ4Bu4Jmp0n2fJN5vBe/hLGaECupq3edn1j/k7O0bFA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
-        "vscode-json-languageservice": "^4.0.2"
+        "vscode-json-languageservice": "^4.1.6"
       }
     },
     "eslint-plugin-node": {
@@ -1245,18 +1239,18 @@
       }
     },
     "globals": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
-      "integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
     "growl": {
@@ -1291,6 +1285,15 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -1417,10 +1420,13 @@
       "dev": true
     },
     "is-bigint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -1432,34 +1438,38 @@
       }
     },
     "is-boolean-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
-      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-callable": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "dev": true
     },
     "is-core-module": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-      "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
     "is-date-object": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
-      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
-      "dev": true
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -1497,10 +1507,13 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-plain-obj": {
       "version": "2.1.0",
@@ -1509,20 +1522,23 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "has-symbols": "^1.0.2"
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-string": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-      "dev": true
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -1567,9 +1583,9 @@
       }
     },
     "jshint": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.0.tgz",
-      "integrity": "sha512-Nd+md9wIeyfDK+RGrbOBzwLONSTdihGMtyGYU/t7zYcN2EgUa4iuY3VK2oxtPYrW5ycTj18iC+UbhNTxe4C66g==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.1.tgz",
+      "integrity": "sha512-vymzfR3OysF5P774x6zYv0bD4EpH6NWRxpq54wO9mA9RuY49yb1teKSICkLx2Ryx+mfzlVVNNbTBtsRtg78t7g==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
@@ -1903,9 +1919,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "nanoid": {
       "version": "3.1.20",
@@ -2416,9 +2432,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
-      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
+      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
       "dev": true
     },
     "sprintf-js": {
@@ -2561,9 +2577,9 @@
       }
     },
     "tar": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.4.tgz",
-      "integrity": "sha512-kcPWrO8S5ABjuZ/v1xQHP8xCEvj1dQ1d9iAb6Qs4jLYzaAIYWwST2IQpz7Ud8VNYRI+fGhFjrnzRKmRggKWg3g==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
+      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -2687,9 +2703,9 @@
       }
     },
     "vscode-json-languageservice": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.6.tgz",
-      "integrity": "sha512-DIKb3tcfRtb3tIE6g9SLOl5E9tNSt6kljH08Wa5RwFlVshtXGrDDzttchze4CYy9pJpE9mBtCbRHmLvY1Z1ZXA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.7.tgz",
+      "integrity": "sha512-cwG5TwZyHYthsk2aS3W1dVgVP6Vwn3o+zscwN58uMgZt/nKuyxd9vdEB1F58Ix+S5kSKAnkUCP6hvulcoImQQQ==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dev": "dev/start.sh",
     "dev:oneoff": "dev/oneoff.sh",
     "dev:repo:reset": "dev/repo/reset.sh",
-    "dev:reinstall": "rm -rf node_modules && npm install --unsafe-perm"
+    "dev:reinstall": "rm -rf node_modules && rm -rf dist && npm install --unsafe-perm"
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.5",


### PR DESCRIPTION
This is a maintenance pull request for GitHub Actions.

1. Commit c445469 removes a TODO from the Prep workflow (docker-node.yml). The workflow is triggered by a push of a Dockerfile. Hence it has already [ran successfully](https://github.com/appoptics/appoptics-bindings-node/actions/runs/1143814102) on commits in this Pull Request (and is also listed as part of the ["checks"](https://github.com/appoptics/appoptics-bindings-node/pull/71/checks) for this PR)

2. Commit 7403646 updates all other workflow so that all jobs have a name and spacing is consistent. There is *no* functionality change.

3. Commit 981de93 changes branch ending silencing GitHub push action to `-no-action` (replaced `-no-build`). This matches what will be used in downstream repo.

4. A series of commits upgrades Dockerfiles from which repo images are built to node versions: `12.22.5`, `14.17.5` and `16.6.1`.

5. Some dev setup changes are piggybacking this pull request.