### PR TITLE
AO-20081-Refactor-GitHub-Actions-Test-Publish-Workflows-10

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -298,19 +298,19 @@ manual (test?) ──► └┬────────────────�
 * To Release:
   1. On branch run `npm version {major/minor/patch}`(e.g. `npm version patch`) then have the branch pass through the Push/Pull/Merge flow above. 
   2. When ready `git push` origin {tag name} (e.g. `git push origin v11.2.3`).
-* Pushing a semantic versioning tag for a patch/minor/major versions (e.g. `v11.2.3`) or an alpha tagged pre-release (e.g. `v11.2.3-alpha.2`) will trigger [release.yml](./workflows/release.yml). Pushing other pre-release tags (e.g. `v11.2.3-7`) is ignored.
+* Pushing a semantic versioning tag for a patch/minor/major versions (e.g. `v11.2.3`) or an prerelease tagged pre-release (e.g. `v11.2.3-prerelease.2`) will trigger [release.yml](./workflows/release.yml). Pushing other pre-release tags (e.g. `v11.2.3-7`) is ignored.
 * Workflow will: 
   - Build the code pushed in each of the Build Group images. 
   - Package the built code and upload a tarball to the *production* S3 bucket. 
   - Create all Target Group images and install the prebuilt tarball on each.
-  - Publish an NPM package upon successful completion of all steps above. When version tag is `alpha`, package will be NPM tagged same. When it is a release version, package will be NPM tagged `latest`.
+  - Publish an NPM package upon successful completion of all steps above. When version tag is `prerelease`, package will be NPM tagged same. When it is a release version, package will be NPM tagged `latest`.
 * Workflow ensures node-pre-gyp setup is working in *production* for a wide variety of potential customer configurations.
 * Workflow publishing to NPM registry exposes the NPM package (and the prebuilt tarballs in the *production* S3 bucket) to the public.
 * Note: @appoptics/apm-bindings is not meant to be directly consumed. It is developed as a dependency of [appoptics-apm](https://www.npmjs.com/package/appoptics-apm).
 
 ```
 push semver tag ─► ┌────────────────────────────┐ ─► ─► ─►
-push alpha tag     │Build Group Build & Package │ S3 Package
+push prerelease tag     │Build Group Build & Package │ S3 Package
                    └┬───────────────────────────┘ Production
                     │
                     │   ┌────────────────────┐     │

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Release - Build & Package, Target Prod Install, NPM Publish (on push tag)
 on: 
   push: 
     tags: 
-      # triggered only by major/minor/patch tags and those specifically tagged alpha. 
+      # triggered only by major/minor/patch tags and those specifically tagged prerelease. 
       # standard prerelease tags do not trigger.
       - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+-alpha.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+-prerelease.*'
 
 jobs:
   load-build-group:
@@ -154,7 +154,7 @@ jobs:
       # by default any package published to npm registry is tagged with 'latest'. to set other pass --tag. 
       # any pre-release package (has - in version), regardless of name defined with version preid, will be npm tagged with 'prerelease'.
       # package is scoped to organization (@appoptics/apm-binding) set --access public to avoid 402 Payment Required
-      - name: NPM Publish (alpha)
+      - name: NPM Publish (prerelease)
         run: npm publish --tag prerelease --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/dev/repo/package-patch.js
+++ b/dev/repo/package-patch.js
@@ -1,7 +1,7 @@
 const pkg = require('../../package.json')
 
 const patch = {
-  name: '@appoptics/apm-binding-dev',
+  name: '@appoptics/apm-bindings-dev',
   binary: {
     ...pkg.binary,
     staging_host: 'https://apm-appoptics-bindings-node-dev-staging.s3.amazonaws.com',


### PR DESCRIPTION
This pull-request changes the git tag used to trigger the Release workflow from `alpha` to `prerelease`.

Moving fwd:
- Version promotion will be done with: `npm version prerelease --preid prerelease`.
- Resulting in `"version": "11.0.1-prerelease.1"` in `package.json`. 
- Will be npm tagged `prerelease`. 
- Will generate binaries with name` apm_bindings-v11.0.1-prerelease.1-node-v72-napi-v7-glibc-x64.tar.gz`.

Dev Release result:
- https://github.com/appoptics/appoptics-bindings-node-dev/actions/runs/1199350265
- https://www.npmjs.com/package/@appoptics/apm-binding-dev
- Note: dev package is also tagged `latest` as it is the only version of the package present. For packages with history, the only tag will be `prerelease`.

Also note - the dev repo readme is the full version (from `.github` directory) while the package has the a simple readme from the root. Readme hack works :)