### PR TITLE
11.0.1-prerelease.0

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -210,6 +210,8 @@ The script will:
 
 To start fresh on the dev repo run `npm run dev:repo:reset` again.
 
+When running a [Release](#release---push-version-tag) process with on the dev repo, the package will be published to https://www.npmjs.com/package/@appoptics/apm-bindings-dev. It should be [unpublished](https://docs.npmjs.com/unpublishing-packages-from-the-registry) as soon as possible. Note that because the package is scoped to the organization, the organization admin must temporarily reassign this package to just the dev-internal team; this team has a single member, which is one of the requirements for unpublishing per https://docs.npmjs.com/policies/unpublish#packages-published-more-than-72-hours-ago.
+
 # Development & Release with GitHub Actions 
 
 > **tl;dr** Push to feature branch. Create Pull Request. Merge Pull Request. Push version tag to release.

--- a/.github/README.md
+++ b/.github/README.md
@@ -210,7 +210,7 @@ The script will:
 
 To start fresh on the dev repo run `npm run dev:repo:reset` again.
 
-When running a [Release](#release---push-version-tag) process with on the dev repo, the package will be published to https://www.npmjs.com/package/@appoptics/apm-bindings-dev. It should be [unpublished](https://docs.npmjs.com/unpublishing-packages-from-the-registry) as soon as possible. Note that because the package is scoped to the organization, the organization admin must temporarily reassign this package to just the dev-internal team; this team has a single member, which is one of the requirements for unpublishing per https://docs.npmjs.com/policies/unpublish#packages-published-more-than-72-hours-ago.
+When running a [Release](#release---push-version-tag) process on the dev repo, the package will be published to https://www.npmjs.com/package/@appoptics/apm-bindings-dev. It should be [unpublished](https://docs.npmjs.com/unpublishing-packages-from-the-registry) as soon as possible. Note that because the package is scoped to the organization, the organization admin must temporarily reassign this package to just the dev-internal team; this team has a single member, which is one of the requirements for unpublishing per https://docs.npmjs.com/policies/unpublish#packages-published-more-than-72-hours-ago.
 
 # Development & Release with GitHub Actions 
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -247,7 +247,7 @@ manual ──────────► └────────────
   - Build the code pushed on a default image. (`node` image from docker hub).
   - Run the tests against the build.
 * Workflow confirms code is not "broken".
-* Manual trigger supported. Enables to node version.
+* Manual trigger supported. Enables to select node version.
 * Naming a branch with `-no-action` ending disables this workflow. Use for documentation branches edited via GitHub UI.
 ```
 push to branch ──► ┌───────────────────┐ ─► ─► ─► ─► ─►

--- a/.github/README.md
+++ b/.github/README.md
@@ -245,7 +245,7 @@ manual ──────────► └────────────
   - Build the code pushed on a default image. (`node` image from docker hub).
   - Run the tests against the build.
 * Workflow confirms code is not "broken".
-* Manual trigger supported. Enables to select image from docker hub or local files (e.g. `erbium-buster-slim`) to build code on.
+* Manual trigger supported. Enables to node version.
 * Naming a branch with `-no-action` ending disables this workflow. Use for documentation branches edited via GitHub UI.
 ```
 push to branch ──► ┌───────────────────┐ ─► ─► ─► ─► ─►
@@ -338,7 +338,7 @@ push prerelease tag     │Build Group Build & Package │ S3 Package
 
 1. Create a docker file with a unique name to be used as a tag. Common is to use: `{node-version}-{os-name-version}` (e.g `16-ubuntu20.04.2.Dockerfile`). If image is a build image suffix with `-build`.
 2. Place a Docker file in the `docker-node` directory.
-3. Due to [GitHub Action issues](https://github.com/actions/runner/issues/1202) Manual trigger of [docker-node.yml] is required.
+3. Push to GitHub.
 
 ### Modifying group lists
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@appoptics/apm-bindings",
-  "version": "11.0.1-alpha.1",
+  "version": "11.0.1-prerelease.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "!darwin",
     "!win32"
   ],
-  "version": "11.0.1-alpha.1",
+  "version": "11.0.1-prerelease.0",
   "appoptics": {
     "version-suffix": "lambda-1"
   },


### PR DESCRIPTION
Prerelease run with accumulated documentation updates.

Note: 

We've decided that "packages maintainers may release as many prerelease versions as they deem appropriate" without need for SolarWinds approval.

Merging this pull request does not trigger the prerelease.
The trigger is by git tag push that will come after all workflows pass..

Future prereleases will not contain such message.