### PR TITLE
AO-20626-Workflows-Halt-Due-to-Fallback-Group-Install

### DIFF
--- a/.github/config/fallback-group.json
+++ b/.github/config/fallback-group.json
@@ -28,9 +28,6 @@
       "image": "node:16-buster"
     },
     {
-      "image": "node:16-stretch"
-    },
-    {
       "image": "node:16-bullseye"
     }
   ]

--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -103,6 +103,9 @@
       "image": "node:16-stretch-slim"
     },
     {
+      "image": "node:16-stretch"
+    },
+    {
       "image": "node:16-bullseye-slim"
     },
     {


### PR DESCRIPTION
This Pull Request moves `node:16-stretch` from Fallback Group to Prebuilt Group. 

Image can not build due Node 16 upgrading to node-gyp@8 which requires Python 3.6 which does not ship with Debian 9 Stretch (has 3.5). 

This is a permanent change.

Reference:
* NPM issue and discussion pointers: https://github.com/npm/run-script/issues/40
* NPM not reverting to node-gyp@7: https://github.com/npm/run-script/pull/41
* node-gyp not reverting python 3.5: https://github.com/nodejs/node-gyp/issues/2540

Workflow passes: https://github.com/appoptics/appoptics-bindings-node/actions/runs/1413186370
