### PR TITLE
AO-20594-Add-Support-for-Node-17

### DIFF
--- a/.github/config/build-group.json
+++ b/.github/config/build-group.json
@@ -24,6 +24,12 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-centos7-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.9-build"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-centos7-build"
     }
   ]
 }

--- a/.github/config/docker-node.json
+++ b/.github/config/docker-node.json
@@ -64,10 +64,34 @@
       "tag": "16-amazonlinux2"
     },
     {
-      "tag": "16-centos7"
+      "tag": "17-centos7"
     },
     {
-      "tag": "16-centos8"
+      "tag": "17-centos8"
+    },
+    {
+      "tag": "17-alpine3.9-build"
+    },
+    {
+      "tag": "17-centos7-build"
+    },
+    {
+      "tag": "17-alpine3.9"
+    },
+    {
+      "tag": "17-alpine3.10"
+    },
+    {
+      "tag": "17-alpine3.11"
+    },
+    {
+      "tag": "17-amazonlinux2"
+    },
+    {
+      "tag": "17-centos7"
+    },
+    {
+      "tag": "17-centos8"
     }
   ]
 }

--- a/.github/config/fallback-group.json
+++ b/.github/config/fallback-group.json
@@ -29,6 +29,12 @@
     },
     {
       "image": "node:16-bullseye"
+    },
+    {
+      "image": "node:17-buster"
+    },
+    {
+      "image": "node:17-bullseye"
     }
   ]
 }

--- a/.github/config/fallback-group.json
+++ b/.github/config/fallback-group.json
@@ -28,9 +28,6 @@
       "image": "node:16-buster"
     },
     {
-      "image": "node:16-stretch"
-    },
-    {
       "image": "node:16-bullseye"
     }
   ]

--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -103,6 +103,9 @@
       "image": "node:16-stretch-slim"
     },
     {
+      "image": "node:16-stretch"
+    },
+    {
       "image": "node:16-bullseye-slim"
     },
     {

--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -134,6 +134,45 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-amazonlinux2"
+    },
+    {
+      "image": "node:17-buster-slim"
+    },
+    {
+      "image": "node:17-stretch-slim"
+    },
+    {
+      "image": "node:17-stretch"
+    },
+    {
+      "image": "node:17-bullseye-slim"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.9"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.10"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.11"
+    },
+    {
+      "image": "node:17-alpine3.12"
+    },
+    {
+      "image": "node:17-alpine3.13"
+    },
+    {
+      "image": "node:17-alpine3.14"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-amazonlinux2"
     }
   ]
 }

--- a/.github/config/target-group.json
+++ b/.github/config/target-group.json
@@ -164,6 +164,51 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-amazonlinux2"
+    },
+    {
+      "image": "node:17-buster"
+    },
+    {
+      "image": "node:17-buster-slim"
+    },
+    {
+      "image": "node:17-stretch"
+    },
+    {
+      "image": "node:17-bullseye"
+    },
+    {
+      "image": "node:17-stretch-slim"
+    },
+    {
+      "image": "node:17-bullseye-slim"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.9"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.10"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-alpine3.11"
+    },
+    {
+      "image": "node:17-alpine3.12"
+    },
+    {
+      "image": "node:17-alpine3.13"
+    },
+    {
+      "image": "node:17-alpine3.14"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-centos7"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-centos8"
+    },
+    {
+      "image": "ghcr.io/$GITHUB_REPOSITORY/node:17-amazonlinux2"
     }
   ]
 }

--- a/.github/docker-node/12-amazonlinux2.Dockerfile
+++ b/.github/docker-node/12-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 12.22.5
+ENV NODE_VERSION 12.22.7
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/12-centos7-build.Dockerfile
+++ b/.github/docker-node/12-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 12.22.5
+ENV NODE_VERSION 12.22.7
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/12-centos7.Dockerfile
+++ b/.github/docker-node/12-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 12.22.5
+ENV NODE_VERSION 12.22.7
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/12-centos8.Dockerfile
+++ b/.github/docker-node/12-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 12.22.5
+ENV NODE_VERSION 12.22.7
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/14-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/14-alpine3.9-build.Dockerfile
@@ -1,10 +1,10 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/a16a841095bcefefaf0ec43ba39f91fc788b03d4/14/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/a70c43d47528213ef0cd58af7c35edf4c1d3e990/14/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
 
 # begin copied content
 FROM alpine:3.9
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.18.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -16,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="8889a3ea0d0d8247132cf257ccd4828ddcd7e373f67c875878035b131e9fa1ac" \
+          CHECKSUM="8d6d2b71b76dc31bbcf12827b9e60212bc04a556c3498e75708d38f5eb4ae6eb" \
           ;; \
         *) ;; \
       esac \
@@ -75,7 +75,7 @@ RUN addgroup -g 1000 node \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.15
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/.github/docker-node/14-alpine3.9.Dockerfile
+++ b/.github/docker-node/14-alpine3.9.Dockerfile
@@ -1,10 +1,10 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/a16a841095bcefefaf0ec43ba39f91fc788b03d4/14/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/a70c43d47528213ef0cd58af7c35edf4c1d3e990/14/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
 
 # begin copied content
 FROM alpine:3.9
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.18.1
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -16,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="8889a3ea0d0d8247132cf257ccd4828ddcd7e373f67c875878035b131e9fa1ac" \
+          CHECKSUM="8d6d2b71b76dc31bbcf12827b9e60212bc04a556c3498e75708d38f5eb4ae6eb" \
           ;; \
         *) ;; \
       esac \
@@ -75,7 +75,7 @@ RUN addgroup -g 1000 node \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.15
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/.github/docker-node/14-amazonlinux2.Dockerfile
+++ b/.github/docker-node/14-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.18.1
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/14-centos7-build.Dockerfile
+++ b/.github/docker-node/14-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.18.1
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/14-centos7.Dockerfile
+++ b/.github/docker-node/14-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.18.1
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/14-centos8.Dockerfile
+++ b/.github/docker-node/14-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.18.1
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-alpine3.10.Dockerfile
+++ b/.github/docker-node/16-alpine3.10.Dockerfile
@@ -1,10 +1,10 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/3047652162a4f83f68260aabfdbb688e58e7b152/16/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/d146f71011bc87d739c9ed3e2820726af7d75417/16/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.10
 
 # begin copied content
 FROM alpine:3.10
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -16,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="0db4ef6dad22a9758017dcac856024b665394688a6c582c604008abdb0c3cff6" \
+          CHECKSUM="f78b7f49c92559855d7804b67101a0da393ad75950317c9138a15cd05292f7a6" \
           ;; \
         *) ;; \
       esac \
@@ -75,7 +75,7 @@ RUN addgroup -g 1000 node \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.15
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/.github/docker-node/16-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.9-build.Dockerfile
@@ -1,10 +1,10 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/3047652162a4f83f68260aabfdbb688e58e7b152/16/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/d146f71011bc87d739c9ed3e2820726af7d75417/16/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
 
 # begin copied content
 FROM alpine:3.9
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -16,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="0db4ef6dad22a9758017dcac856024b665394688a6c582c604008abdb0c3cff6" \
+          CHECKSUM="f78b7f49c92559855d7804b67101a0da393ad75950317c9138a15cd05292f7a6" \
           ;; \
         *) ;; \
       esac \
@@ -75,7 +75,7 @@ RUN addgroup -g 1000 node \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.15
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/.github/docker-node/16-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/16-alpine3.9-build.Dockerfile
@@ -105,6 +105,6 @@ CMD [ "node" ]
 # install software required for this OS
 RUN apk update && apk add \
   g++ \
-  python2 \
+  python3 \
   make
 

--- a/.github/docker-node/16-alpine3.9.Dockerfile
+++ b/.github/docker-node/16-alpine3.9.Dockerfile
@@ -1,10 +1,10 @@
-# Taken from https://raw.githubusercontent.com/nodejs/docker-node/3047652162a4f83f68260aabfdbb688e58e7b152/16/alpine3.11/Dockerfile
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/d146f71011bc87d739c9ed3e2820726af7d75417/16/alpine3.11/Dockerfile
 # Only modification FROM alpine:3.9
 
 # begin copied content
 FROM alpine:3.9
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 RUN addgroup -g 1000 node \
     && adduser -u 1000 -G node -s /bin/sh -D node \
@@ -16,7 +16,7 @@ RUN addgroup -g 1000 node \
       && case "${alpineArch##*-}" in \
         x86_64) \
           ARCH='x64' \
-          CHECKSUM="0db4ef6dad22a9758017dcac856024b665394688a6c582c604008abdb0c3cff6" \
+          CHECKSUM="f78b7f49c92559855d7804b67101a0da393ad75950317c9138a15cd05292f7a6" \
           ;; \
         *) ;; \
       esac \
@@ -75,7 +75,7 @@ RUN addgroup -g 1000 node \
   && node --version \
   && npm --version
 
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.15
 
 RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 # install software required for this OS
 RUN yum -y install \

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_VERSION 16.13.0
 
 # install software required for this OS
 RUN yum -y install \
-  python2 \
+  python3 \
   make
 
 # yum install gcc-c++  will install version 4.8.5

--- a/.github/docker-node/16-centos7.Dockerfile
+++ b/.github/docker-node/16-centos7.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/16-centos8.Dockerfile
+++ b/.github/docker-node/16-centos8.Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:8
 
-ENV NODE_VERSION 16.8.0
+ENV NODE_VERSION 16.13.0
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/.github/docker-node/17-alpine3.10.Dockerfile
+++ b/.github/docker-node/17-alpine3.10.Dockerfile
@@ -1,0 +1,103 @@
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/eeed4a818e7cd954dbd4fff34de1afb8555b834f/17/alpine3.12/Dockerfile
+# Only modification FROM alpine:3.10
+
+# begin copied content
+FROM alpine:3.10
+
+ENV NODE_VERSION 17.0.1
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="2fe80ab23de32b91a9f7679725369da1eb7833e778d2e16fdc31049d57cdc098" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.15
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]
+# end copied content

--- a/.github/docker-node/17-alpine3.11.Dockerfile
+++ b/.github/docker-node/17-alpine3.11.Dockerfile
@@ -1,0 +1,103 @@
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/eeed4a818e7cd954dbd4fff34de1afb8555b834f/17/alpine3.12/Dockerfile
+# Only modification FROM alpine:3.11
+
+# begin copied content
+FROM alpine:3.11
+
+ENV NODE_VERSION 17.0.1
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="2fe80ab23de32b91a9f7679725369da1eb7833e778d2e16fdc31049d57cdc098" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.15
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]
+# end copied content

--- a/.github/docker-node/17-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/17-alpine3.9-build.Dockerfile
@@ -1,0 +1,110 @@
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/eeed4a818e7cd954dbd4fff34de1afb8555b834f/17/alpine3.12/Dockerfile
+# Only modification FROM alpine:3.9
+
+# begin copied content
+FROM alpine:3.9
+
+ENV NODE_VERSION 17.0.1
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="2fe80ab23de32b91a9f7679725369da1eb7833e778d2e16fdc31049d57cdc098" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.15
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]
+# end copied content
+
+# install software required for this OS
+RUN apk update && apk add \
+  g++ \
+  python2 \
+  make
+

--- a/.github/docker-node/17-alpine3.9-build.Dockerfile
+++ b/.github/docker-node/17-alpine3.9-build.Dockerfile
@@ -105,6 +105,6 @@ CMD [ "node" ]
 # install software required for this OS
 RUN apk update && apk add \
   g++ \
-  python2 \
+  python3 \
   make
 

--- a/.github/docker-node/17-alpine3.9.Dockerfile
+++ b/.github/docker-node/17-alpine3.9.Dockerfile
@@ -1,0 +1,103 @@
+# Taken from https://raw.githubusercontent.com/nodejs/docker-node/eeed4a818e7cd954dbd4fff34de1afb8555b834f/17/alpine3.12/Dockerfile
+# Only modification FROM alpine:3.9
+
+# begin copied content
+FROM alpine:3.9
+
+ENV NODE_VERSION 17.0.1
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="2fe80ab23de32b91a9f7679725369da1eb7833e778d2e16fdc31049d57cdc098" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python3 \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      108F52B48DB57BB0CC439B2997B01419BD92F80A \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.15
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
+    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD [ "node" ]
+# end copied content

--- a/.github/docker-node/17-amazonlinux2.Dockerfile
+++ b/.github/docker-node/17-amazonlinux2.Dockerfile
@@ -1,0 +1,29 @@
+FROM amazonlinux:2
+
+ENV NODE_VERSION 17.0.1
+
+# install software required for this OS
+RUN yum -y install \
+    tar \
+    gzip
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/.github/docker-node/17-centos7-build.Dockerfile
+++ b/.github/docker-node/17-centos7-build.Dockerfile
@@ -1,0 +1,37 @@
+FROM centos:7
+
+ENV NODE_VERSION 17.0.1
+
+# install software required for this OS
+RUN yum -y install \
+  python2 \
+  make
+
+# yum install gcc-c++  will install version 4.8.5
+# we need a higher version that supports c++ 14.
+# see: https://github.com/nodejs/node/blob/master/BUILDING.md#supported-toolchains
+# following will get version 8.3.1 and set as default
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-8-gcc*
+
+ENV PATH=/opt/rh/devtoolset-8/root/bin:$PATH
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/17-centos7-build.Dockerfile
+++ b/.github/docker-node/17-centos7-build.Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_VERSION 17.0.1
 
 # install software required for this OS
 RUN yum -y install \
-  python2 \
+  python3 \
   make
 
 # yum install gcc-c++  will install version 4.8.5

--- a/.github/docker-node/17-centos7.Dockerfile
+++ b/.github/docker-node/17-centos7.Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:7
+
+ENV NODE_VERSION 17.0.1
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/.github/docker-node/17-centos8.Dockerfile
+++ b/.github/docker-node/17-centos8.Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:8
+
+ENV NODE_VERSION 17.0.1
+
+# install nvm
+ENV NVM_DIR /root/.nvm
+
+# install nvm using a pre-vetted script
+COPY nvm-v0.38.0-install.sh /
+RUN bash nvm-v0.38.0-install.sh
+
+ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
+ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH
+
+# install node and npm
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:latest
 SHELL ["/bin/bash", "-c"]
 
 # general tools
@@ -32,11 +32,13 @@ ENV NVM_DIR /root/.nvm
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 
-# these are the stable versions as of July 2021
-# cant use lts alias due to all sorts of Dockerfile limitations.
+# these are the stable versions as of November 2021
+# can't use lts alias due to all sorts of Dockerfile limitations.
 RUN source $NVM_DIR/nvm.sh \
-    && nvm install v14.17.5 \
-    && nvm install v12.22.5 \
+    && nvm install v14.18.1 \
+    && nvm install v17.0.1 \
+    && nvm install v16.13.0 \
+    && nvm install v12.22.7 \
     && nvm install v10.24.1 \
     && nvm install stable
 
@@ -44,5 +46,5 @@ RUN source $NVM_DIR/nvm.sh \
 # stay with 14.
 
 # add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v14.17.5/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v14.17.5/bin:$PATH
+ENV NODE_PATH $NVM_DIR/v14.18.1/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v14.18.1/bin:$PATH


### PR DESCRIPTION
This Pull Request adds support for Node 17 by:
1. Adding the Dockerfiles(image build been triggered by push)
2. Adding resulting images to config groups.

It also updates Node 12, 14 and 16 images to latest versions as well as the dev environment.

Support for Node 17 required no additional adjustments compared to [node 16](https://github.com/appoptics/appoptics-bindings-node/pull/56).

Note that we still build and test node 17 on alpine 3.9 (our base) even though 3.9 (as well as 3.10 and 3.11) is [EOL](https://endoflife.date/alpine). This can be reconsidered for 18.

Build test run pass: https://github.com/appoptics/appoptics-bindings-node/actions/runs/1422124163