### PR TITLE
Fix-oboe_metadata_fromstr-Call

### DIFF
--- a/src/settings.cc
+++ b/src/settings.cc
@@ -127,6 +127,7 @@ Napi::Value getTraceSettings(const Napi::CallbackInfo& info) {
       if (xtrace.length() == 60) {
         // try to convert it to metadata. if it fails act as if no xtrace was
         // supplied.
+        oboe_metadata_init(&omd);
         int status = oboe_metadata_fromstr(&omd, xtrace.c_str(), xtrace.length());
         // status can be zero with a version other than 2, so check that too.
         if (status < 0 || omd.version != 2) {


### PR DESCRIPTION
This Pull request added oboe_metadata_init call before calling oboe_metadata_fromstr as required by liboboe api.

All tests pass.