### PR TITLE
AO-20476-liboboe-Checksum

### DIFF
--- a/.github/scripts/liboboe-checksum.sh
+++ b/.github/scripts/liboboe-checksum.sh
@@ -13,9 +13,8 @@ error_files=""
 
 for f in $files; do
     # get data from binary file and sha256 file
-
-    echo "Downloading ${url}/${version}/$f.sha256"
     version=$(cat ./oboe/VERSION)
+    echo "Downloading ${url}/${version}/$f.sha256"
     curl -o "./oboe/${f}.sha256" "${url}/${version}/$f.sha256"
 
     correct=$(awk '{print $1}' < "./oboe/$f.sha256")

--- a/.github/scripts/liboboe-checksum.sh
+++ b/.github/scripts/liboboe-checksum.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# input is a space delimited string of files to checksum
+# e.g. "liboboe-1.0-x86_64.so.0.0.0 liboboe-1.0-alpine-x86_64.so.0.0.0 liboboe-1.0-lambda-x86_64.so.0.0.0"
+# we assume each file has a matching .sha256 file.
+files="$1"
+
+# hard coded location of sha files
+url="https://files.appoptics.com/c-lib"
+
+errors=0
+error_files=""
+
+for f in $files; do
+    # get data from binary file and sha256 file
+
+    echo "Downloading ${url}/${version}/$f.sha256"
+    version=$(cat ./oboe/VERSION)
+    curl -o "./oboe/${f}.sha256" "${url}/${version}/$f.sha256"
+
+    correct=$(awk '{print $1}' < "./oboe/$f.sha256")
+    checked=$(sha256sum "./oboe/$f" | awk '{print $1}')
+    
+    # All cases
+    if [ "$checked" != "$correct" ] || [ "$checked" = "" ] || [ "$correct" = "" ]; then
+        errors=$((errors + 1))
+        error_files="$error_files $f"
+        echo "WARNING: SHA256 for $f DOES NOT MATCH!"
+        echo "found    ${checked:-nothing}"
+        echo "expected ${correct:-SHA}"
+    else
+        echo "SHA256 matches expected value for $f"
+    fi
+done 
+
+if [ "$errors" -gt 0 ]; then
+    echo "$errors SHA mismatches:$error_files"
+    exit 1 # Exit with error will halt workflow run
+fi

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
+      - name: Checksum Liboboe
+        run: .github/scripts/liboboe-checksum.sh "liboboe-1.0-x86_64.so.0.0.0 liboboe-1.0-alpine-x86_64.so.0.0.0 liboboe-1.0-lambda-x86_64.so.0.0.0"
+
         # build with the lowest versions of the OSes supported so the glibc/musl versions are the oldest/most compatible. 
         # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
       - name: Load build group data

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v2
 
+      - name: Checksum Liboboe
+        run: .github/scripts/liboboe-checksum.sh "liboboe-1.0-x86_64.so.0.0.0 liboboe-1.0-alpine-x86_64.so.0.0.0 liboboe-1.0-lambda-x86_64.so.0.0.0"
+
         # build with the lowest versions of the OSes supported so the glibc/musl versions # are the oldest/most compatible. 
         # note: some of those images are no longer supported officially (https://hub.docker.com/_/node)
       - name: Load build group data

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -68,3 +68,16 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  checksum:
+    name: Checksum Liboboe
+    runs-on: ubuntu-latest 
+    needs: build-group-test
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Checksum Liboboe
+        run: .github/scripts/liboboe-checksum.sh "liboboe-1.0-x86_64.so.0.0.0 liboboe-1.0-alpine-x86_64.so.0.0.0 liboboe-1.0-lambda-x86_64.so.0.0.0"
+

--- a/dev/env.sh
+++ b/dev/env.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+ARG=$1
+
+if [ ! -f /.dockerenv ]; then 
+  echo "Must run from inside the dev container."
+  exit 
+fi
+
+Which=$(which "${0#-}")
+
+case $Which in
+    */bin/sh)
+    ;;
+    */bin/bash)
+    ;;
+
+    *)
+    echo
+    echo "this script must be sourced so the environment variables can be set."
+    echo
+    /bin/false
+    return
+    ;;
+esac
+
+# define this in all cases.
+if [ "$ARG" = "stg" ]; then
+    [ -z "$AO_TOKEN_STG" ] && echo "Missing AO_TOKEN_STG, aborting" && return 1
+    export APPOPTICS_SERVICE_KEY="${AO_TOKEN_STG}":node-bindings-test
+elif [ "$ARG" = "prod" ]; then
+    [ -z "$AO_TOKEN_PROD" ] && echo "Missing AO_TOKEN_PROD, aborting" && return 1
+    export APPOPTICS_SERVICE_KEY="${AO_TOKEN_PROD}":node-bindings-test
+fi
+
+
+if [ "$ARG" = "udp" ]; then
+    export APPOPTICS_REPORTER=udp
+    export APPOPTICS_COLLECTOR="${AO_TEST_COLLECTOR:-localhost:7832}"
+elif [ "$ARG" = "stg" ]; then
+    export APPOPTICS_REPORTER=ssl
+    export APPOPTICS_COLLECTOR="${AO_TEST_COLLECTOR:-collector-stg.appoptics.com}"
+elif [ "$ARG" = "prod" ]; then
+    export APPOPTICS_REPORTER=ssl
+    export APPOPTICS_COLLECTOR="${AO_TEST_COLLECTOR:-collector.appoptics.com}"
+else
+    echo
+    echo "source this script with an argument of udp or stg or prod. it"
+    echo "will define environment variables to enable testing with"
+    echo "the specified reporter".
+    echo
+fi
+
+return

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "dev": "dev/start.sh",
     "dev:oneoff": "dev/oneoff.sh",
     "dev:repo:reset": "dev/repo/reset.sh",
-    "dev:reinstall": "rm -rf node_modules && rm -rf dist && npm install --unsafe-perm"
+    "dev:reinstall": "rm -rf node_modules && rm -rf dist && npm install --unsafe-perm",
+    "dev:oboe": "./dev/oboe.sh"
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.5",


### PR DESCRIPTION
This pull request adds a chucksum step to Accept and Release workflows. It ensures that the binaries in the repo match the binaries published to the bucket.

Commit (97a41d70520a028cdd4261b1fb79de3e14f6fb72) added script to checksum oboe binaries against sha256 files downloaded for current version from https://files.appoptics.com/c-lib.

Commit (87960477921af850f0237761c575a47eb2c82e2f) Modified Accept and Release workflows to perform checksum as part of first job (loading data). Workflow will err and stop if checksum do not match.

Commit (87960477921af850f0237761c575a47eb2c82e2f) Modified the Review workflow to perform checksum as a step at the end of the workflow. Workflow will err and stop if checksum do not match but only after building and testing.

If binaries are replaced the workflows will halt. 

Commit (a11c1de) is a dev setup change related to oboe that is "piggy backing" this pull request. It splits `env.sh` script into two separate functional scripts placed in the dev directory.
- `oboe.sh` (accessible via npm run dev:oboe) handles downloading and checksum versions of oboe.
- `env.sh` (must be sourced) is minor helper script changing environment variables used for testing.
Both scripts only run from within the dev container.

Notes:
- The Review workflow chucksums after the build and test. This allows it to be used for "quick builds" on multiple platforms with unpublished versions of liboboe while still providing pull request indication that something is wrong.
- The Accept workflow will only run after a merge to master, hence, it is still up to developer to make sure Pull Requests are with appropriate binaries.
- No release without correct checksums.