### PR TITLE
AO-20749-build-NAPI-4-Only

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   "gypfile": true,
   "binary": {
     "napi_versions": [
-      4,
-      7
+      4
     ],
     "module_name": "apm_bindings",
     "module_path": "./dist/{node_napi_label}",


### PR DESCRIPTION
### Overview:

This pull request sets `node-pre-gyp` to only build one set of binaries using Node API version 4.

According to [Node-API version matrix](https://nodejs.org/api/n-api.html#node-api-version-matrix):

> Node-API versions are *additive* and versioned independently from Node.js. Version 4 is an extension to version 3 in that it has all of the APIs from version 3 with some additions. This means that it is *not necessary to recompile for new versions of Node.js which are listed as supporting a later version*.

NAPI 4 is good for everything from Node v10.16.0 and above.

### Status:

A January commit added NAPI 7 to the build versions: https://github.com/appoptics/appoptics-bindings-node/commit/c443f6454533123c8745fc51b3c927bd6ae16dde Since then we have been building and distributing a double set of binaries. This is unnecessary.

### Notes:
- By observation, `node-pre-gyp` will use the highest number version when presented with two options. However, when presented with only a NAPI 4 version, [the extensive set of install tests pass](https://github.com/appoptics/appoptics-bindings-node/actions/runs/1534062354).