### PR TITLE
NH-5266-Adapt-Event.toString-functionality

### DIFF
--- a/test/event-to-string-mode-0.test.js
+++ b/test/event-to-string-mode-0.test.js
@@ -1,0 +1,134 @@
+/* global describe, before, it */
+'use strict'
+
+/* eslint-disable new-cap  */
+
+const bindings = require('../')
+const expect = require('chai').expect
+
+const env = process.env
+const maxIsReadyToSampleWait = 60000
+
+describe('addon.event.toString() mode 0', function () {
+  before(function () {
+    const serviceKey = process.env.APPOPTICS_SERVICE_KEY || `${env.AO_TOKEN_STG}:node-bindings-test`
+    const endpoint = process.env.APPOPTICS_COLLECTOR || 'collector-stg.appoptics.com'
+
+    this.timeout(maxIsReadyToSampleWait)
+    const status = bindings.oboeInit({ serviceKey, endpoint })
+    // oboeInit can return -1 for already initialized or 0 if succeeded.
+    // depending on whether this is run as part of a suite or standalone
+    // either result is valid.
+    if (status !== -1 && status !== 0) {
+      throw new Error('oboeInit() failed')
+    }
+
+    const ready = bindings.isReadyToSample(maxIsReadyToSampleWait)
+    expect(ready).equal(1, `should be connected to ${endpoint} and ready`)
+  })
+
+  /*
+    from bindings.h
+
+    const static int ff_header = 1;
+    const static int ff_task = 2;
+    const static int ff_op = 4;
+    const static int ff_flags = 8;
+    const static int ff_sample = 16;
+    const static int ff_separators = 32;
+    const static int ff_lowercase = 64;
+
+  */
+  it('should return xtrace when no argument is provided', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+
+    expect(event.toString().length).equal(60)
+    expect(event.toString().slice(0, 2)).equal('2B')
+    expect(event.toString().slice(-2)).equal('00')
+  })
+
+  // see event-to-string comment
+  it('should return a lowercase delimited xtrace when argument is 1', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const taskId = data.slice(2, -18)
+    const opId = data.slice(-18, -2)
+    const flags = data.slice(-2)
+
+    expect(event.toString(1)).equal(`2b-${taskId.toLowerCase()}-${opId.toLowerCase()}-${flags}`)
+  })
+
+  it('should return just task id when argument is 2', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const taskId = data.slice(2, -18)
+
+    expect(event.toString(2)).equal(taskId)
+  })
+
+  it('should return just op id when argument is 4', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const opId = data.slice(-18, -2)
+
+    expect(event.toString(4)).equal(opId)
+  })
+
+  it('should return just flags when argument is 8', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const flags = data.slice(-2)
+
+    expect(event.toString(8)).equal(flags)
+  })
+
+  it('should return just the sample byte when argument is 16', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const byte = data.slice(-1)
+
+    expect(event.toString(16)).equal(byte)
+  })
+
+  it('should return a lowercased parts when argument is 66', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const taskId = data.slice(2, -18)
+
+    expect(event.toString(66)).equal(taskId.toLowerCase())
+  })
+
+  it('should return a lowercased parts when argument is 68', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const opId = data.slice(-18, -2)
+
+    expect(event.toString(68)).equal(opId.toLowerCase())
+  })
+
+  it('should return a delimited opIdflags when argument is 108', function () {
+    const xtraceData = new bindings.Event.makeRandom()
+    const event = new bindings.Event(xtraceData)
+    const data = event.toString()
+
+    const opId = data.slice(-18, -2)
+    const flags = data.slice(-2)
+
+    expect(event.toString(108)).equal(`${opId.toLowerCase()}-${flags}`)
+  })
+})

--- a/test/event-to-string-mode-1.test.js
+++ b/test/event-to-string-mode-1.test.js
@@ -9,13 +9,13 @@ const expect = require('chai').expect
 const env = process.env
 const maxIsReadyToSampleWait = 60000
 
-describe('addon.event.toString()', function () {
+describe('addon.event.toString() mode 1', function () {
   before(function () {
-    const serviceKey = process.env.APPOPTICS_SERVICE_KEY || `${env.AO_TOKEN_STG}:node-bindings-test`
-    const endpoint = process.env.APPOPTICS_COLLECTOR || 'collector-stg.appoptics.com'
+    const serviceKey = process.env.APPOPTICS_SERVICE_KEY || `${env.AO_TOKEN_NH}:node-bindings-test`
+    const endpoint = process.env.APPOPTICS_COLLECTOR || `${env.APPOPTICS_COLLECTOR_NH}`
 
     this.timeout(maxIsReadyToSampleWait)
-    const status = bindings.oboeInit({ serviceKey, endpoint })
+    const status = bindings.oboeInit({ serviceKey, endpoint, mode: 1 })
     // oboeInit can return -1 for already initialized or 0 if succeeded.
     // depending on whether this is run as part of a suite or standalone
     // either result is valid.
@@ -36,16 +36,20 @@ describe('addon.event.toString()', function () {
     const static int ff_flags = 8;
     const static int ff_sample = 16;
     const static int ff_separators = 32;
-    const static int ff_lowercase = 64;
+    const static int ff_lowercase = 64; // in mode 1 everything is always lowervase
 
   */
-  it('should return xtrace when no argument is provided', function () {
+  it('should return traceparent when no argument is provided', function () {
     const xtraceData = new bindings.Event.makeRandom()
     const event = new bindings.Event(xtraceData)
 
-    expect(event.toString().length).equal(60)
-    expect(event.toString().slice(0, 2)).equal('2B')
+    expect(event.toString().length).equal(55)
+    expect(event.toString().slice(0, 2)).equal('00')
     expect(event.toString().slice(-2)).equal('00')
+
+    expect(event.toString().split('-').length).equal(4)
+    expect(event.toString().split('-')[1].length).equal(32)
+    expect(event.toString().split('-')[2].length).equal(16)
   })
 
   // see event-to-string comment
@@ -54,11 +58,11 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const taskId = data.slice(2, -18)
-    const opId = data.slice(-18, -2)
-    const flags = data.slice(-2)
+    const taskId = data.split('-')[1]
+    const opId = data.split('-')[2]
+    const flags = data.split('-')[3]
 
-    expect(event.toString(1)).equal(`2b-${taskId.toLowerCase()}-${opId.toLowerCase()}-${flags}`)
+    expect(event.toString(1)).equal(`00-${taskId}-${opId}-${flags}`)
   })
 
   it('should return just task id when argument is 2', function () {
@@ -66,7 +70,7 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const taskId = data.slice(2, -18)
+    const taskId = data.split('-')[1]
 
     expect(event.toString(2)).equal(taskId)
   })
@@ -76,7 +80,7 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const opId = data.slice(-18, -2)
+    const opId = data.split('-')[2]
 
     expect(event.toString(4)).equal(opId)
   })
@@ -86,7 +90,7 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const flags = data.slice(-2)
+    const flags = data.split('-')[3]
 
     expect(event.toString(8)).equal(flags)
   })
@@ -106,7 +110,7 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const taskId = data.slice(2, -18)
+    const taskId = data.split('-')[1]
 
     expect(event.toString(66)).equal(taskId.toLowerCase())
   })
@@ -116,7 +120,7 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const opId = data.slice(-18, -2)
+    const opId = data.split('-')[2]
 
     expect(event.toString(68)).equal(opId.toLowerCase())
   })
@@ -126,8 +130,8 @@ describe('addon.event.toString()', function () {
     const event = new bindings.Event(xtraceData)
     const data = event.toString()
 
-    const opId = data.slice(-18, -2)
-    const flags = data.slice(-2)
+    const opId = data.split('-')[2]
+    const flags = data.split('-')[3]
 
     expect(event.toString(108)).equal(`${opId.toLowerCase()}-${flags}`)
   })


### PR DESCRIPTION
### Overview:

This pull request adds mode 1 (traceparent) support to the Event toString method which can generate various formatted outputs. Tests for both mode 0 and mode 1 are included. Support for outdated versions of oboe metadata have been removed.

### Status:
Formatting functionality was added to bindings in https://github.com/appoptics/appoptics-bindings-node/commit/dd6556b2dd20c2a183f6d2adca538850eb099745 and tests (for xtrace) were added in https://github.com/appoptics/appoptics-bindings-node/commit/4d15d8512c9d53a925e457bc17d40bbbbf478a73.

### Notes:
- Pull Request merges into oboe-10.3.0 branch.
- Tests that run on branch include [added tests](https://github.com/appoptics/appoptics-bindings-node/actions/runs/1552715261).
- [Last Review check](https://github.com/appoptics/appoptics-bindings-node/runs/4453431725?check_suite_focus=true) is a liboboe checksum. It fails, by design, as 10.3.0 is still staged.
