### PR TITLE
NH-5263-Store-Prebuilt-Staging-Binaries-at-solarwinds-apm-staging

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -68,7 +68,7 @@ Those are available in the Docker Dev Container.
 `git clone` to start.
 
 * `src` directory contains the C++ code to bind to liboboe. 
-* `oboe` directory contains `liboboe` and its required header files. `liboboe` is downloaded from: https://files.appoptics.com/c-lib. Pre-release versions are at: https://rc-files-t2.s3-us-west-2.amazonaws.com/c-lib/
+* `oboe` directory contains `liboboe` and its required header files. `liboboe` is downloaded from: https://files.appoptics.com/c-lib. Pre-release versions are at: https://solarwinds-apm-staging.s3-us-west-2.amazonaws.com/c-lib/
 * `test` directory contains the test suite. 
 * `.github` contains the files for github actions.
 * `dev` directory contains anything related to dev environment

--- a/dev/oboe.sh
+++ b/dev/oboe.sh
@@ -48,7 +48,7 @@ get_new_oboe() {
     # presume production
     URL="https://files.appoptics.com/c-lib"
     if [ "$SOURCE" = "STAGING" ]; then
-        URL="https://s3-us-west-2.amazonaws.com/rc-files-t2/c-lib"
+        URL="https://s3-us-west-2.amazonaws.com/solarwinds-apm-staging/c-lib"
     elif [ "$SOURCE" != "PRODUCTION" ]; then
         echo "Invalid SOURCE value $SOURCE, aborting"
         exit 1

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ],
     "module_name": "apm_bindings",
     "module_path": "./dist/{node_napi_label}",
-    "staging_host": "https://rc-files-t2.s3-us-west-2.amazonaws.com",
+    "staging_host": "https://solarwinds-apm-staging.s3-us-west-2.amazonaws.com",
     "production_host": "https://appoptics-binaries.s3.amazonaws.com",
     "host": "",
     "remote_path": "./nodejs/bindings",


### PR DESCRIPTION
### Overview:

This pull request changes the staging bucket used to store prebuilt binaries and obtain liboboe.
Bucket is now `solarwinds-apm-staging.s3-us-west-2.amazonaws.com`

### Status:

Since 10.3.0 is still staged, the Accept Workflow that builds binaries and places them in the staging bucket, will halt due to liboboe not passing a production checksum.

Pull Request was tested using the dev repo with checksum protection disabled.
[Build succeeded](https://github.com/appoptics/appoptics-bindings-node-dev/actions/runs/1551534614).

### Notes:
- Pull Request merges into oboe-10.3.0 branch.
- [Last Review check](https://github.com/appoptics/appoptics-bindings-node/runs/4453420720?check_suite_focus=true) is a liboboe checksum. It fails, by design, as 10.3.0 is still staged.
