### PR TITLE
AO-21079-Do-Not-Pass-xtrace-String-to-Oboe-when-Empty

### DIFF
--- a/src/settings.cc
+++ b/src/settings.cc
@@ -189,9 +189,16 @@ Napi::Value getTraceSettings(const Napi::CallbackInfo& info) {
   // apply default or user specified values.
   in.version = 2;
   in.service_name = "";
-  in.in_xtrace = xtrace.c_str();
   in.custom_sample_rate = rate;
   in.custom_tracing_mode = mode;
+
+  // oboe logs an error for an empty xtrace (and then ignores it)
+  // only set key when existing
+  if(!xtrace.empty()) {
+    in.in_xtrace = xtrace.c_str();
+  } else {
+    in.in_xtrace = nullptr;
+  }
 
   // v2 fields (added for trigger-trace support)
   in.custom_trigger_mode = customTriggerMode;


### PR DESCRIPTION
## Overview

This pull request fixes an issue causing oboe to log errors (and then gracefully proceed) during normal operation.

## Status

When a request comes in without an x-trace header (which would be the majority of requests) the agent passes an object to the bindings. When there is no incoming x-trace, the object has an empty string in the xtrace key. The bindings then act on the xtrace value accordingly. However, when a data struct is sent to to oboe to make the tracing decision, x-trace is always set to a string. Thus, when it is an empty string, oboe will log an error.

`[Fri Mar 25 23:36:51 2022] oboe_sample_layer: passed in x-trace seems invalid, ignoring [settings.c:948] [AppOptics-settings-low p#1.1]`


## Change

A conditional was added around the the value of xtrace in the struct sent to oboe for tracing decisions. Now xtrace is set to null pointer when xtrace is empty, preventing an oboe error log.