### PR TITLE
NH-11002-Refactor-Tests-and-GH-Actions-for-Dual-Repo-and-Backends

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -62,7 +62,9 @@ Those are available in the Docker Dev Container.
 ## Docker Dev Container
 
 1. Start the Docker daemon (on a Mac that would be simplest using Docker desktop).
-2. Create a `.env` file and set: `APPOPTICS_SERVICE_KEY={a valid service key}`, `APPOPTICS_COLLECTOR={a url of the collector}` and `AO_TEST_PROD_SERVICE_KEY={a valid **production** service key}`.
+2. Create a `.env` file and set two sets of keys for both backends:
+- `APPOPTICS_SERVICE_KEY={a valid service key}`, `APPOPTICS_COLLECTOR={a url of the collector}` and `AO_TEST_PROD_SERVICE_KEY={a valid **production** service key}`.
+- `SW_APM_SERVICE_KEY={a valid service key}`, `SW_APM_COLLECTOR={a url of the collector}` and `SW_TEST_PROD_SERVICE_KEY={a valid **production** service key}`.
 3. Run `npm run dev`. This will create a docker container, set it up, and open a shell. Docker container will have all required build tools as well as nano installed, and access to GitHub SSH keys as configured. Repo code is **mounted** to the container.
 4. To open another shell in same container use: `docker exec -it dev-bindings /bin/bash`
 
@@ -365,6 +367,10 @@ Repo is defined with the following secrets:
 APPOPTICS_SERVICE_KEY
 APPOPTICS_COLLECTOR
 AO_TEST_PROD_SERVICE_KEY
+SW_APM_SERVICE_KEY
+SW_APM_COLLECTOR
+SW_TEST_PROD_SERVICE_KEY
+
 STAGING_AWS_ACCESS_KEY_ID
 STAGING_AWS_SECRET_ACCESS_KEY
 PROD_AWS_ACCESS_KEY_ID

--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -102,8 +102,9 @@ jobs:
       APPOPTICS_SERVICE_KEY: ${{ secrets.APPOPTICS_SERVICE_KEY }}
       APPOPTICS_COLLECTOR: ${{ secrets.APPOPTICS_COLLECTOR }}
       AO_TEST_PROD_SERVICE_KEY: ${{ secrets.AO_TEST_PROD_SERVICE_KEY }}
-      AO_TOKEN_NH: ${{ secrets.AO_TOKEN_NH }}
-      APPOPTICS_COLLECTOR_NH: ${{ secrets.APPOPTICS_COLLECTOR_NH }}
+      SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+      SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+      SW_TEST_PROD_SERVICE_KEY: ${{ secrets.SW_TEST_PROD_SERVICE_KEY }}
 
     steps:
       # See comment at bottom of file.
@@ -215,8 +216,9 @@ jobs:
       APPOPTICS_SERVICE_KEY: ${{ secrets.APPOPTICS_SERVICE_KEY }}
       APPOPTICS_COLLECTOR: ${{ secrets.APPOPTICS_COLLECTOR }}
       AO_TEST_PROD_SERVICE_KEY: ${{ secrets.AO_TEST_PROD_SERVICE_KEY }}
-      AO_TOKEN_NH: ${{ secrets.AO_TOKEN_NH }}
-      APPOPTICS_COLLECTOR_NH: ${{ secrets.APPOPTICS_COLLECTOR_NH }}
+      SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+      SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+      SW_TEST_PROD_SERVICE_KEY: ${{ secrets.SW_TEST_PROD_SERVICE_KEY }}
 
     steps:
       # See comment at bottom of file.

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,8 +26,9 @@ jobs:
       APPOPTICS_SERVICE_KEY: ${{ secrets.APPOPTICS_SERVICE_KEY }}
       APPOPTICS_COLLECTOR: ${{ secrets.APPOPTICS_COLLECTOR }}
       AO_TEST_PROD_SERVICE_KEY: ${{ secrets.AO_TEST_PROD_SERVICE_KEY }}
-      AO_TOKEN_NH: ${{ secrets.AO_TOKEN_NH }}
-      APPOPTICS_COLLECTOR_NH: ${{ secrets.APPOPTICS_COLLECTOR_NH }}
+      SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+      SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+      SW_TEST_PROD_SERVICE_KEY: ${{ secrets.SW_TEST_PROD_SERVICE_KEY }}
 
     steps:
       - name: Checkout ${{ github.ref }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,8 +36,9 @@ jobs:
       APPOPTICS_SERVICE_KEY: ${{ secrets.APPOPTICS_SERVICE_KEY }}
       APPOPTICS_COLLECTOR: ${{ secrets.APPOPTICS_COLLECTOR }}
       AO_TEST_PROD_SERVICE_KEY: ${{ secrets.AO_TEST_PROD_SERVICE_KEY }}
-      AO_TOKEN_NH: ${{ secrets.AO_TOKEN_NH }}
-      APPOPTICS_COLLECTOR_NH: ${{ secrets.APPOPTICS_COLLECTOR_NH }}
+      SW_APM_SERVICE_KEY: ${{ secrets.SW_APM_SERVICE_KEY }}
+      SW_APM_COLLECTOR: ${{ secrets.SW_APM_COLLECTOR }}
+      SW_TEST_PROD_SERVICE_KEY: ${{ secrets.SW_TEST_PROD_SERVICE_KEY }}
 
     steps:
       # the working directory is created by the runner and mounted to the container.

--- a/package-lock.json
+++ b/package-lock.json
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1104.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1104.0.tgz",
-      "integrity": "sha512-MQbjCtU+1el6XkHcOgC+FYTEdC/dQvG6Qn5kO3EbPmVKctMRjuEXYzpRB+vTYR+iZbdJYBE7A6EEthdg3iQkbA==",
+      "version": "2.1107.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1107.0.tgz",
+      "integrity": "sha512-gZaCm+zSSwjUYSa/cVg63uXhq5w9coT9yA8aTDOYzFkyl19b9H2CCixPeyf7KHtZdGwe3QAG2Oe6Rw0xtoCs+Q==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -1978,10 +1978,13 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
       "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3823,9 +3826,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1104.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1104.0.tgz",
-      "integrity": "sha512-MQbjCtU+1el6XkHcOgC+FYTEdC/dQvG6Qn5kO3EbPmVKctMRjuEXYzpRB+vTYR+iZbdJYBE7A6EEthdg3iQkbA==",
+      "version": "2.1107.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1107.0.tgz",
+      "integrity": "sha512-gZaCm+zSSwjUYSa/cVg63uXhq5w9coT9yA8aTDOYzFkyl19b9H2CCixPeyf7KHtZdGwe3QAG2Oe6Rw0xtoCs+Q==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -4965,9 +4968,9 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
       "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
@@ -4990,10 +4993,13 @@
       }
     },
     "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
     },
     "is-string": {
       "version": "1.0.7",

--- a/test/bindings.test.js
+++ b/test/bindings.test.js
@@ -41,19 +41,19 @@ describe('bindings.oboeInit()', function () {
   // tests here always run against production collector. no way to "override" with settings.
 
   it('should initialize oboe with only a service key', function () {
-    const result = bindings.oboeInit({ serviceKey: `${env.AO_TOKEN_NH}:node-bindings-test`, mode: 1 })
+    const result = bindings.oboeInit({ serviceKey: `${env.SW_TEST_PROD_SERVICE_KEY}`, mode: 1 })
     // oboeInit can return -1 for already initialized or 0 if succeeded.
     // depending on whether this is run as part of a suite or standalone
     // either result is valid.
     expect(result).oneOf([-1, 0])
   })
 
-  it('should check if ready to sample using collector.appoptics.com', function () {
+  it('should check if ready to sample using collector', function () {
     this.timeout(maxIsReadyToSampleWait)
     const ready = bindings.isReadyToSample(maxIsReadyToSampleWait)
     expect(ready).be.a('number')
 
-    expect(ready).equal(1, 'collector.appoptics.com should be ready')
+    expect(ready).equal(1, 'collector should be ready')
   })
 
   it('should handle good options values', function () {
@@ -111,7 +111,7 @@ describe('bindings.oboeInit()', function () {
 
   it('should handle the environment variable values', function () {
     const details = {}
-    const envVars = new EnvVarOptions('APPOPTICS_')
+    const envVars = new EnvVarOptions('SW_APM_')
     const options = envVars.getConverted(keyMap)
 
     const result = bindings.oboeInit(options, details)

--- a/test/event-mode-1.test.js
+++ b/test/event-mode-1.test.js
@@ -4,7 +4,6 @@
 const bindings = require('../')
 const expect = require('chai').expect
 
-const env = process.env
 const maxIsReadyToSampleWait = 60000
 
 const evUnsampled = '00-5bd5777ca0077c734b537b64c6b96921-1aa0b1b42979f5c4-00'
@@ -12,8 +11,8 @@ const evSampled = '00-4fc9017ba3404828f253638a697dc7cf-a544d5b98159b555-01'
 
 describe('bindings.Event mode 1', function () {
   before(function () {
-    const serviceKey = process.env.SOLARWINDS_SERVICE_KEY || `${env.AO_TOKEN_NH}:node-bindings-test`
-    const endpoint = process.env.SOLARWINDS_COLLECTOR || `${env.APPOPTICS_COLLECTOR_NH}`
+    const serviceKey = process.env.SW_APM_SERVICE_KEY
+    const endpoint = process.env.SW_APM_COLLECTOR
 
     this.timeout(maxIsReadyToSampleWait)
     const status = bindings.oboeInit({ serviceKey, endpoint, mode: 1 })
@@ -26,6 +25,32 @@ describe('bindings.Event mode 1', function () {
 
     const ready = bindings.isReadyToSample(maxIsReadyToSampleWait)
     expect(ready).equal(1, `should be connected to ${endpoint} and ready`)
+  })
+
+  it('should throw if the constructor is called without "new"', function () {
+    function badCall () {
+      bindings.Event()
+    }
+    expect(badCall, 'should throw without "new"').throws(TypeError, 'Class constructors cannot be invoked without \'new\'')
+  })
+
+  it('should succeed when called with no arguments', function () {
+    const event = new bindings.Event()
+    expect(event).instanceof(bindings.Event)
+  })
+
+  it('should throw if the constructor is called without an event', function () {
+    const tests = [
+      { args: [1], text: 'non-metadata', e: 'invalid signature' },
+      { args: ['invalid-x-trace-string'], text: 'invalid x-trace', e: 'invalid signature' }
+    ]
+
+    for (const t of tests) {
+      function badCall () {
+        new bindings.Event(...t.args) // eslint-disable-line no-new
+      }
+      expect(badCall, `${t.text} should throw "${t.e}"`).throws(TypeError, t.e)
+    }
   })
 
   it('should construct an event using an event', function () {

--- a/test/event-to-string-mode-0.test.js
+++ b/test/event-to-string-mode-0.test.js
@@ -8,7 +8,7 @@ const expect = require('chai').expect
 
 const maxIsReadyToSampleWait = 60000
 
-describe('addon.event.toString() mode 0', function () {
+describe('bindings.event.toString() mode 0', function () {
   before(function () {
     const serviceKey = process.env.APPOPTICS_SERVICE_KEY
     const endpoint = process.env.APPOPTICS_COLLECTOR

--- a/test/event-to-string-mode-1.test.js
+++ b/test/event-to-string-mode-1.test.js
@@ -6,13 +6,12 @@
 const bindings = require('../')
 const expect = require('chai').expect
 
-const env = process.env
 const maxIsReadyToSampleWait = 60000
 
 describe('bindings.Event.toString() mode 1', function () {
   before(function () {
-    const serviceKey = process.env.SOLARWINDS_SERVICE_KEY || `${env.AO_TOKEN_NH}:node-bindings-test`
-    const endpoint = process.env.SOLARWINDS_COLLECTOR || `${env.APPOPTICS_COLLECTOR_NH}`
+    const serviceKey = process.env.SW_APM_SERVICE_KEY
+    const endpoint = process.env.SW_APM_COLLECTOR
 
     this.timeout(maxIsReadyToSampleWait)
     const status = bindings.oboeInit({ serviceKey, endpoint, mode: 1 })

--- a/test/expose-gc/reporter-metrics-memory.test.js
+++ b/test/expose-gc/reporter-metrics-memory.test.js
@@ -7,8 +7,8 @@ const expect = require('chai').expect
 const maxIsReadyToSampleWait = 60000
 
 describe('reporter-metrics-memory', function () {
-  const serviceKey = `${process.env.AO_TOKEN_NH}:node-bindings-test`
-  const endpoint = `${process.env.APPOPTICS_COLLECTOR_NH}`
+  const serviceKey = process.env.SW_APM_SERVICE_KEY
+  const endpoint = process.env.SW_APM_COLLECTOR
 
   const metrics = []
   const batchSize = 100

--- a/test/reporter-metrics.test.js
+++ b/test/reporter-metrics.test.js
@@ -8,8 +8,8 @@ const maxIsReadyToSampleWait = 60000
 
 describe('bindings.Reporter.sendMetrics()', function () {
   before(function () {
-    const serviceKey = `${process.env.AO_TOKEN_NH}:node-bindings-test`
-    const endpoint = `${process.env.APPOPTICS_COLLECTOR_NH}`
+    const serviceKey = process.env.SW_APM_SERVICE_KEY
+    const endpoint = process.env.SW_APM_COLLECTOR
 
     this.timeout(maxIsReadyToSampleWait)
     const status = bindings.oboeInit({ serviceKey, endpoint, mode: 1 })

--- a/test/reporter.test.js
+++ b/test/reporter.test.js
@@ -8,8 +8,8 @@ const maxIsReadyToSampleWait = 60000
 
 describe('bindings.Reporter', function () {
   before(function () {
-    const serviceKey = `${process.env.AO_TOKEN_NH}:node-bindings-test`
-    const endpoint = `${process.env.APPOPTICS_COLLECTOR_NH}`
+    const serviceKey = process.env.SW_APM_SERVICE_KEY
+    const endpoint = process.env.SW_APM_COLLECTOR
 
     this.timeout(maxIsReadyToSampleWait)
     const status = bindings.oboeInit({ serviceKey, endpoint, mode: 1 })

--- a/test/settings-mode-1.test.js
+++ b/test/settings-mode-1.test.js
@@ -4,13 +4,12 @@
 const bindings = require('../')
 const expect = require('chai').expect
 
-const env = process.env
 const maxIsReadyToSampleWait = 60000
 
 describe('bindings.Settings mode 1', function () {
   before(function () {
-    const serviceKey = process.env.SOLARWINDS_SERVICE_KEY || `${env.AO_TOKEN_NH}:node-bindings-test`
-    const endpoint = process.env.SOLARWINDS_COLLECTOR || `${env.APPOPTICS_COLLECTOR_NH}`
+    const serviceKey = process.env.SW_APM_SERVICE_KEY
+    const endpoint = process.env.SW_APM_COLLECTOR
 
     this.timeout(maxIsReadyToSampleWait)
     const status = bindings.oboeInit({ serviceKey, endpoint, mode: 1 })


### PR DESCRIPTION
## Overview

This pull request refactors the test and GitHub Actions setup so that they work with a duo of backends.
It is a change to the `oboe-10.3.0` branch corresponding the one made in #103 to the `master` branch.

## Change

1. Updated tests:
- Removed all hard coded urls.
- Removed use of private environment variables `AO_TOKEN_PROD` and `AO_TOKEN_STG`. Instead use new standard public environment variables `SW_APM_SERVICE_KEY`, `SW_APM_COLLECTOR` to set which servers test run against when in mode 1.
- Added `SW_TEST_PROD_SERVICE_KEY` environment variable to cover the specific test case of initialization without url in mode 1.
2. Updated GH Actions to set new environment variables as required by modified tests.
3. Updated documentation to reflect changes in tests and GH Action setup.
4. Ran `npm audit fix` and `npm update`.

## Notes
- Pull Request merges into `oboe-10.3.0` branch. Bindings built from `master` will stay unchanged.
- This is a repo only change. No code change and thus no need for future release of bindings as result of this pull request.
- New repo secrets were added to match to newly used environment variables. Cleanup of unused will be done after merge.