### PR TITLE
AO-20470-Update-Release-Workflow-to-Make-it-Fail-Safe

### DIFF
--- a/.github/scripts/is-published.sh
+++ b/.github/scripts/is-published.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# for the name and version specified in package.json
+pkg=$(node -e "console.log(require('./package.json').name)")
+version=$(node -e "console.log(require('./package.json').version)")
+
+# check if package was already published
+published=$(npm view "$pkg" versions --json | grep "$version")
+
+# if it was error will halt workflow
+if [ "$published" != "" ]; then
+    echo "$published already published to NPM registry."
+    exit 1 
+fi

--- a/.github/scripts/is-published.sh
+++ b/.github/scripts/is-published.sh
@@ -3,11 +3,12 @@
 # for the name and version specified in package.json
 pkg=$(node -e "console.log(require('./package.json').name)")
 version=$(node -e "console.log(require('./package.json').version)")
+echo "Checking $version of $pkg."
 
-# check if package was already published
+# check if package version was already published
 published=$(npm view "$pkg" versions --json | grep "$version")
 
-# if it was error will halt workflow
+# if it was published - an error will halt workflow
 if [ "$published" != "" ]; then
     echo "$published already published to NPM registry."
     exit 1 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,27 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-prerelease.*'
 
 jobs:
+  is-published:
+    name: Check if package published
+    runs-on: ubuntu-latest 
+
+    steps:
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Setup Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Check is published version
+        run: .github/scripts/is-published.sh 
+
   load-build-group:
+    # both build-group-unpublish and  build-group-publish "needs" this job
     name: Load Build Group Config JSON
     runs-on: ubuntu-latest
+    needs: is-published
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
@@ -28,10 +46,51 @@ jobs:
         id: set-matrix
         run: .github/scripts/matrix-from-json.sh .github/config/build-group.json
 
+  # if this workflow fails and aborts before the NPM package is published it leaves artifacts in the S3 bucket.
+  # step above confirmed version was never published.
+  # step below removes any artifacts (if exist) from bucket to allow publishing in the publish step to run.
+  build-group-unpublish:
+    name: Build Group Unpublish
+    runs-on: ubuntu-latest
+    needs: load-build-group
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.load-build-group.outputs.matrix) }}
+    container:
+        image:  ${{ matrix.image }}
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      # See comment at bottom of file.
+      - name: Change Owner of Container Working Directory
+        run: chown root:root .
+
+      - name: Checkout ${{ github.ref }}
+        uses: actions/checkout@v2
+
+      - name: Show Environment Info
+        run: |
+          printenv
+          node --version
+          npm --version
+          cat /etc/os-release
+
+      # must install dependencies before using node-pre-gyp
+      # rather not call npm install as doing so may fallback-to-build if package has yet to be published.
+      # use npm workaround specifying a package name to bypass install script in package.json
+      - name: NPM Install dependencies
+        run: npm install linux-os-info --unsafe-perm
+
+      - name: Clear Production for version
+        run: npx node-pre-gyp unpublish --s3_host=production
+
   build-group-publish:
     name: Build Group Publish
     runs-on: ubuntu-latest 
-    needs: load-build-group
+    needs: [load-build-group, build-group-unpublish]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.load-build-group.outputs.matrix) }}


### PR DESCRIPTION
## Overview

This pull request updateds the GithHub Actions Release workflow so that it becomes "fail safe" and can be re-run without issues in case a failure happened during a previous run.

## Status

The bindings package is published in a two step process. First prebuilt add-on tarballs are uploaded to an S3 bucket using `node-pre-gyp`, and then an NPM package is published to the NPM . Prebuilt tarballs must be versioned with the same version as the NPM package and they must be present in the S3 bucket prior to the NPM package itself being published to the registry.

The process is automated using the Release workflow (https://github.com/appoptics/appoptics-bindings-node/tree/master/.github#release---push-version-tag) which, after the build and publish of the tarballs , also installs them on multiple operating systems.

There exists a possibility of failure in the GitHub Actions run that leaves published artifacts in the S3 bucket but aborts before the NPM package is published.

In such a case a rerun of the workflow will fail because `node-pre-gyp` will not overwrite when publishing. 

Currently  - in case of such failure, the node package maintainer logs into the production S3 bucket - deletes the tarballs - and then reruns the GithHub workflow. 

This is undesirable.

## Change

The Release workflow was modified so that:

1. It checks if the version of the package being released (as in package.json) has been published before - if it did - aborts.
2. Unpublish tarballs from production bucket (if they exist).

This setup is similar to the one used in the Accept workflow( ) against the staging S3 bucket.

## Implementation

For maintainability, checking if a version has been published is implemented using an external shell script.