### PR TITLE
NH-11306-Gracefully-Disable-Lambda-Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "!win32"
   ],
   "version": "12.0.0-nh.0",
-  "appoptics": {
-    "version-suffix": "lambda-1"
-  },
   "description": "Bindings for appoptics-apm with pre-built support",
   "author": "Bruce A. MacNaughton <bruce.macnaughton@solarwinds.com>",
   "contributors": [


### PR DESCRIPTION
## Overview

The lambda implementation suffers form several issues (AO-19620, AO-19603, AO-19911, AO-20761) and thus serverless support would not initially ship for `solarwinds-apm`.

## Change

This pull request removes the version suffix used by lambda from package.json. All other lambda related functionality, added in #27, is left as-is.

## Notes
- Pull Request merges into `nh-main` branch. Bindings built from `master` will stay unchanged.