### PR TITLE
Update-NVM-Install-Script-to-0.39.1-latest

### DIFF
--- a/.github/docker-node/10-amazonlinux2.Dockerfile
+++ b/.github/docker-node/10-amazonlinux2.Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/10-centos7-build.Dockerfile
+++ b/.github/docker-node/10-centos7-build.Dockerfile
@@ -12,8 +12,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/10-centos7.Dockerfile
+++ b/.github/docker-node/10-centos7.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 10.24.1
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/10-centos8.Dockerfile
+++ b/.github/docker-node/10-centos8.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 10.24.1
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/12-amazonlinux2.Dockerfile
+++ b/.github/docker-node/12-amazonlinux2.Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/12-centos7-build.Dockerfile
+++ b/.github/docker-node/12-centos7-build.Dockerfile
@@ -12,8 +12,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/12-centos7.Dockerfile
+++ b/.github/docker-node/12-centos7.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 12.22.12
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/12-centos8.Dockerfile
+++ b/.github/docker-node/12-centos8.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 12.22.12
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/14-amazonlinux2.Dockerfile
+++ b/.github/docker-node/14-amazonlinux2.Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/14-centos7-build.Dockerfile
+++ b/.github/docker-node/14-centos7-build.Dockerfile
@@ -12,8 +12,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/14-centos7.Dockerfile
+++ b/.github/docker-node/14-centos7.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 14.19.1
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/14-centos8.Dockerfile
+++ b/.github/docker-node/14-centos8.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 14.19.1
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/16-amazonlinux2.Dockerfile
+++ b/.github/docker-node/16-amazonlinux2.Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/16-centos7-build.Dockerfile
+++ b/.github/docker-node/16-centos7-build.Dockerfile
@@ -20,8 +20,8 @@ ENV PATH=/opt/rh/devtoolset-8/root/bin:$PATH
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/16-centos7.Dockerfile
+++ b/.github/docker-node/16-centos7.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 16.14.2
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/16-centos8.Dockerfile
+++ b/.github/docker-node/16-centos8.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 16.14.2
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/18-amazonlinux2022.Dockerfile
+++ b/.github/docker-node/18-amazonlinux2022.Dockerfile
@@ -11,8 +11,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/18-rhel8-build.Dockerfile
+++ b/.github/docker-node/18-rhel8-build.Dockerfile
@@ -12,8 +12,8 @@ RUN yum -y install \
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/.github/docker-node/18-rhel8.Dockerfile
+++ b/.github/docker-node/18-rhel8.Dockerfile
@@ -6,8 +6,8 @@ ENV NODE_VERSION 18.0.0
 ENV NVM_DIR /root/.nvm
 
 # install nvm using a pre-vetted script
-COPY nvm-v0.38.0-install.sh /
-RUN bash nvm-v0.38.0-install.sh
+COPY nvm-v0.39.1-install.sh /
+RUN bash nvm-v0.39.1-install.sh
 
 ENV NODE_PATH /root/.nvm/v$NODE_VERSION/lib/node_modules
 ENV PATH /root/.nvm/versions/node/v$NODE_VERSION/bin:$PATH

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
 # install nvm
 ENV NVM_DIR /root/.nvm
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 
 # these are the stable versions as of April 2022
 # can't use lts alias due to all sorts of Dockerfile limitations.


### PR DESCRIPTION
## Overview

This pull request updates the repo copy of the NVM install script used by GitHub Actions (as well as the dev setup) to the latest version (0.39.1).

## Tests

Images [build correctly](https://github.com/appoptics/appoptics-bindings-node/actions/runs/2221495036) and are [usable](https://github.com/appoptics/appoptics-bindings-node/actions/runs/2221510367).