### PR TITLE
11.2.1-prerelease.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appoptics/apm-bindings",
-  "version": "11.2.1-prerelease.0",
+  "version": "11.2.1-prerelease.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appoptics/apm-bindings",
-      "version": "11.2.1-prerelease.0",
+      "version": "11.2.1-prerelease.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "!darwin",
     "!win32"
   ],
-  "version": "11.2.1-prerelease.0",
+  "version": "11.2.1-prerelease.1",
   "appoptics": {
     "version-suffix": "lambda-1"
   },


### PR DESCRIPTION
Prerelease run (for manual release workflow).

Note:

We've decided that "packages maintainers may release as many prerelease versions as they deem appropriate" without need for SolarWinds approval.

Merging this pull request does not trigger the prerelease.
The trigger is by manual start of a GitHub  workflow that will come after all workflows pass.