### PR TITLE
AO-20750-Test-Coverage-for-Sanitizer (additional)

### DIFF
--- a/test/sanitizer.test.js
+++ b/test/sanitizer.test.js
@@ -54,4 +54,21 @@ describe('bindings.Sanitizer', function () {
     const result = Sanitizer.sanitize(sql)
     expect(result).equal("SELECT `users`.* FROM `users` WHERE (mobile IN ('?') AND email IN ('?')) LIMIT 0")
   })
+
+  it('should not remove numbers from column names \'', function () {
+    const sql = 'UPDATE my_table SET col1 = 10, col2 = 20, col3 = 30 WHERE col1 = 1'
+    const result = Sanitizer.sanitize(sql)
+    expect(result).equal('UPDATE my_table SET col1 = 0, col2 = 0, col3 = 0 WHERE col1 = 0')
+  })
+
+  // Note the FSM (as copied from the PHP agent) can NOT handle an escaped value correctly.
+  it('would NOT properly handle escaped \'', function () {
+    const sql = "SELECT * FROM test_table tbl1 WHERE tbl1.name = 'jake\'s' GROUP BY tbl1.name"
+    const result = Sanitizer.sanitize(sql)
+    // below not really what we would expect.
+    // we would expect: SELECT * FROM test_table tbl1 WHERE tbl1.name = ? GROUP BY tbl1.name
+    // however the sanitizer can't handle that. No fix will be implemented as current agent is EOL 
+    // and future version of the agent will use a regex as in the ruby agent.
+    expect(result).equal("SELECT * FROM test_table tbl1 WHERE tbl1.name = '?'s'?")
+  })
 })


### PR DESCRIPTION
## Overview

This pull request increases test coverage of the Sanitizer functionality used to remove details from SQL queries.

## Status
Sanitization was added to the bindings in the first commit https://github.com/appoptics/appoptics-bindings-node/commit/d82692bb8d57b106114dbac7f4efc878054fc214. It is an FSM written in C++ ["copied" from PHP agent](https://github.com/librato/oboe/blob/834a1afb4cfafa2c38e7b8f3bbcf35b528c35ab2/contrib/php_oboe/php-oboe/php-8/sql_parser.cc).

Test coverage based on the [Ruby Agent test coverage](https://github.com/appoptics/appoptics-apm-ruby/blob/c36bd5b597cb37beeb39c2e7fa302efb3ad49d13/test/support/sql_sanitize_test.rb) was added recently in #98.

The additional tests cover strings that are problematic (for FSM and/or Ruby) including a case where sanitization fails to meet expectations but does remove all required details.