### PR TITLE
NH-14717-Remove-Slim-Versions-of-Debian-from-Target-Group

### DIFF
--- a/.github/config/prebuilt-group.json
+++ b/.github/config/prebuilt-group.json
@@ -1,15 +1,6 @@
 {
   "include": [
     {
-      "image": "node:14-buster-slim"
-    },
-    {
-      "image": "node:14-stretch-slim"
-    },
-    {
-      "image": "node:14-bullseye-slim"
-    },
-    {
       "image": "node:14-alpine3.13"
     },
     {
@@ -28,16 +19,7 @@
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-amazonlinux2"
     },
     {
-      "image": "node:16-buster-slim"
-    },
-    {
-      "image": "node:16-stretch-slim"
-    },
-    {
       "image": "node:16-stretch"
-    },
-    {
-      "image": "node:16-bullseye-slim"
     },
     {
       "image": "node:16-alpine3.13"
@@ -56,12 +38,6 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-amazonlinux2"
-    },
-    {
-      "image": "node:18-buster-slim"
-    },
-    {
-      "image": "node:18-bullseye-slim"
     },
     {
       "image": "node:18-alpine3.14"

--- a/.github/config/target-group.json
+++ b/.github/config/target-group.json
@@ -1,15 +1,6 @@
 {
   "include": [
     {
-      "image": "node:14-buster-slim"
-    },
-    {
-      "image": "node:14-stretch-slim"
-    },
-    {
-      "image": "node:14-bullseye-slim"
-    },
-    {
       "image": "node:14-alpine3.13"
     },
     {
@@ -28,16 +19,7 @@
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:14-amazonlinux2"
     },
     {
-      "image": "node:16-buster-slim"
-    },
-    {
-      "image": "node:16-stretch-slim"
-    },
-    {
       "image": "node:16-stretch"
-    },
-    {
-      "image": "node:16-bullseye-slim"
     },
     {
       "image": "node:16-alpine3.13"
@@ -56,12 +38,6 @@
     },
     {
       "image": "ghcr.io/$GITHUB_REPOSITORY/node:16-amazonlinux2"
-    },
-    {
-      "image": "node:18-buster-slim"
-    },
-    {
-      "image": "node:18-bullseye-slim"
     },
     {
       "image": "node:18-alpine3.14"


### PR DESCRIPTION
## Overview

This pull request removes the "slim" images of Debian from the Target (and Prebuilt) groups.

## Status

oboe 10.5.0 removed the hard coded certificate. If the image does not have certificates (like the "Slims" don't) customer must install certificates using `apt update && apt install -y ca-certificates`.

## Notes:
- Test run with "trimmed" Target Group at: https://github.com/appoptics/appoptics-bindings-node/actions/runs/2499210452
- Pull Request merges into `nh-main`. Agent built from `master` has a larger target group`.